### PR TITLE
prepare v0.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
-## 0.1.1
+## 0.1.2
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- Fixed **block element rendering** — Unicode block characters (U+2580–U+259F) now render correctly using CSS gradients and quadrant compositing instead of font glyphs
+- Improved **PTY error handling** — shell spawn failures are now caught gracefully with a user-facing error message before closing the connection
+
+### Improvements
+
+- Removed rounded corners in the local example for a cleaner full-screen look
+
+<!-- release:end -->
+
+## 0.1.1
 
 ### Bug Fixes
 
@@ -15,8 +28,6 @@
 - Refactored greeting message internals
 - Included `wterm.wasm` as a static asset in package configuration
 - Added release process workflow
-
-<!-- release:end -->
 
 ## 0.1.0
 

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Headless terminal emulator core for the web — WASM bridge and WebSocket transport",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/dom",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "DOM renderer, input handler, and orchestrator for wterm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/just-bash",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "just-bash shell adapter for wterm — line editing, tab completion, history, prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/markdown",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Streaming markdown-to-ANSI renderer for wterm terminals",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "React component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bumped all `@wterm/*` packages to **0.1.2**
- Added changelog entry for block element rendering fix, PTY error handling improvement, and local example styling tweak

## Changelog

### Bug Fixes

- Fixed **block element rendering** — Unicode block characters (U+2580–U+259F) now render correctly using CSS gradients and quadrant compositing instead of font glyphs
- Improved **PTY error handling** — shell spawn failures are now caught gracefully with a user-facing error message before closing the connection

### Improvements

- Removed rounded corners in the local example for a cleaner full-screen look