### PR TITLE
Fix terminal input handling and cursor focus state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A terminal emulator for the web.
 
-wterm (pronounced "dub-term") renders to the DOM — native text selection, copy/paste, find, and accessibility come for free. The core is written in Zig and compiled to WASM for near-native performance.
+wterm ("dub-term") renders to the DOM — native text selection, copy/paste, find, and accessibility come for free. The core is written in Zig and compiled to WASM for near-native performance.
 
 ## Packages
 

--- a/apps/docs/src/app/api/docs-chat/route.ts
+++ b/apps/docs/src/app/api/docs-chat/route.ts
@@ -12,7 +12,7 @@ export const maxDuration = 60;
 
 const DEFAULT_MODEL = "anthropic/claude-haiku-4.5";
 
-const SYSTEM_PROMPT = `You are a helpful documentation assistant for wterm (pronounced "dub-term"), a terminal emulator for the web. It renders to the DOM — native text selection, copy/paste, find, and accessibility come for free. The core is written in Zig and compiled to WASM.
+const SYSTEM_PROMPT = `You are a helpful documentation assistant for wterm ("dub-term"), a terminal emulator for the web. It renders to the DOM — native text selection, copy/paste, find, and accessibility come for free. The core is written in Zig and compiled to WASM.
 
 GitHub repository: https://github.com/vercel-labs/wterm
 Documentation: https://wterm.dev

--- a/apps/docs/src/app/introduction/page.mdx
+++ b/apps/docs/src/app/introduction/page.mdx
@@ -12,7 +12,7 @@ import { HeroSection } from "@/components/hero-terminal";
     wterm <span className="text-neutral-400 dark:text-neutral-500">("dub-term")</span> renders to the DOM — native text selection, copy/paste, find, and accessibility come for free. The core is written in Zig and compiled to WASM for near-native performance.
   </div>
   <div className="mt-3 text-xs text-neutral-500 dark:text-neutral-500">
-    Example uses <a href="https://github.com/nicolo-ribaudo/just-bash" className="underline underline-offset-2 hover:text-neutral-700 dark:hover:text-neutral-300">just-bash</a>. See also: <a href="https://github.com/vercel-labs/wterm/tree/main/examples/ssh" className="underline underline-offset-2 hover:text-neutral-700 dark:hover:text-neutral-300">SSH</a>, <a href="https://github.com/vercel-labs/wterm/tree/main/examples/local" className="underline underline-offset-2 hover:text-neutral-700 dark:hover:text-neutral-300">local</a>.
+    Example uses <a href="https://github.com/vercel-labs/just-bash" className="underline underline-offset-2 hover:text-neutral-700 dark:hover:text-neutral-300">just-bash</a>. See also: <a href="https://github.com/vercel-labs/wterm/tree/main/examples/ssh" className="underline underline-offset-2 hover:text-neutral-700 dark:hover:text-neutral-300">SSH</a>, <a href="https://github.com/vercel-labs/wterm/tree/main/examples/local" className="underline underline-offset-2 hover:text-neutral-700 dark:hover:text-neutral-300">local</a>.
   </div>
 </div>
 

--- a/apps/docs/src/app/introduction/page.mdx
+++ b/apps/docs/src/app/introduction/page.mdx
@@ -3,13 +3,13 @@ import { HeroSection } from "@/components/hero-terminal";
 <div className="mb-12">
   <h1 className="mb-6 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">A terminal emulator for the web</h1>
   <div className="mb-8 hidden text-sm leading-relaxed text-neutral-600 dark:text-neutral-400 md:block">
-    wterm <span className="text-neutral-400 dark:text-neutral-500">(pronounced "dub-term")</span> renders to the DOM — native text selection, copy/paste, find, and accessibility come for free. The core is written in Zig and compiled to WASM for near-native performance.
+    wterm <span className="text-neutral-400 dark:text-neutral-500">("dub-term")</span> renders to the DOM — native text selection, copy/paste, find, and accessibility come for free. The core is written in Zig and compiled to WASM for near-native performance.
   </div>
   <div className="mb-6 md:mb-0">
     <HeroSection />
   </div>
   <div className="mt-4 text-sm leading-relaxed text-neutral-600 dark:text-neutral-400 md:hidden">
-    wterm <span className="text-neutral-400 dark:text-neutral-500">(pronounced "dub-term")</span> renders to the DOM — native text selection, copy/paste, find, and accessibility come for free. The core is written in Zig and compiled to WASM for near-native performance.
+    wterm <span className="text-neutral-400 dark:text-neutral-500">("dub-term")</span> renders to the DOM — native text selection, copy/paste, find, and accessibility come for free. The core is written in Zig and compiled to WASM for near-native performance.
   </div>
   <div className="mt-3 text-xs text-neutral-500 dark:text-neutral-500">
     Example uses <a href="https://github.com/nicolo-ribaudo/just-bash" className="underline underline-offset-2 hover:text-neutral-700 dark:hover:text-neutral-300">just-bash</a>. See also: <a href="https://github.com/vercel-labs/wterm/tree/main/examples/ssh" className="underline underline-offset-2 hover:text-neutral-700 dark:hover:text-neutral-300">SSH</a>, <a href="https://github.com/vercel-labs/wterm/tree/main/examples/local" className="underline underline-offset-2 hover:text-neutral-700 dark:hover:text-neutral-300">local</a>.

--- a/apps/docs/src/components/docs-chat.tsx
+++ b/apps/docs/src/components/docs-chat.tsx
@@ -328,6 +328,13 @@ class ChatShell {
         this._cursor++;
         w("\x1b[C");
       }
+    } else if (data === "\x15") {
+      if (this._line.length > 0) {
+        if (this._cursor > 0) w(`\x1b[${this._cursor}D`);
+        w("\x1b[K");
+        this._line = "";
+        this._cursor = 0;
+      }
     } else if (data === "\x01") {
       if (this._cursor > 0) {
         w(`\x1b[${this._cursor}D`);

--- a/apps/docs/src/components/docs-chat.tsx
+++ b/apps/docs/src/components/docs-chat.tsx
@@ -328,6 +328,16 @@ class ChatShell {
         this._cursor++;
         w("\x1b[C");
       }
+    } else if (data === "\x01") {
+      if (this._cursor > 0) {
+        w(`\x1b[${this._cursor}D`);
+        this._cursor = 0;
+      }
+    } else if (data === "\x05") {
+      if (this._cursor < this._line.length) {
+        w(`\x1b[${this._line.length - this._cursor}C`);
+        this._cursor = this._line.length;
+      }
     } else if (data === "\x03") {
       this._line = "";
       this._cursor = 0;

--- a/apps/docs/src/components/docs-chat.tsx
+++ b/apps/docs/src/components/docs-chat.tsx
@@ -65,6 +65,7 @@ class ChatShell {
   private _write: ((data: string) => void) | null = null;
   private _messages: ChatMessage[] = [];
   private _line = "";
+  private _cursor = 0;
   private _busy = false;
   private _history: string[] = [];
   private _historyPos = -1;
@@ -98,6 +99,7 @@ class ChatShell {
   clear() {
     this._messages = [];
     this._line = "";
+    this._cursor = 0;
     this._history = [];
     this._historyPos = -1;
     this._save();
@@ -119,6 +121,7 @@ class ChatShell {
     if (data === "\r") {
       const query = this._line.trim();
       this._line = "";
+      this._cursor = 0;
       w("\r\n");
 
       if (!query) {
@@ -284,9 +287,12 @@ class ChatShell {
         this._showPrompt();
       }
     } else if (data === "\x7f" || data === "\b") {
-      if (this._line.length > 0) {
-        this._line = this._line.slice(0, -1);
-        w("\b \b");
+      if (this._cursor > 0) {
+        const tail = this._line.slice(this._cursor);
+        this._line = this._line.slice(0, this._cursor - 1) + tail;
+        this._cursor--;
+        w("\b" + tail + "\x1b[K");
+        if (tail.length > 0) w(`\x1b[${tail.length}D`);
       }
     } else if (data === "\x1b[A") {
       if (!this._history.length) return;
@@ -296,6 +302,7 @@ class ChatShell {
         const entry = this._history[this._historyPos];
         w(`\r\x1b[1;32m>\x1b[0m \x1b[K${entry}`);
         this._line = entry;
+        this._cursor = entry.length;
       }
     } else if (data === "\x1b[B") {
       if (this._historyPos < 0) return;
@@ -304,21 +311,45 @@ class ChatShell {
         this._historyPos = -1;
         w(`\r\x1b[1;32m>\x1b[0m \x1b[K`);
         this._line = "";
+        this._cursor = 0;
       } else {
         const entry = this._history[this._historyPos];
         w(`\r\x1b[1;32m>\x1b[0m \x1b[K${entry}`);
         this._line = entry;
+        this._cursor = entry.length;
+      }
+    } else if (data === "\x1b[D") {
+      if (this._cursor > 0) {
+        this._cursor--;
+        w("\x1b[D");
+      }
+    } else if (data === "\x1b[C") {
+      if (this._cursor < this._line.length) {
+        this._cursor++;
+        w("\x1b[C");
       }
     } else if (data === "\x03") {
       this._line = "";
+      this._cursor = 0;
       w("^C\r\n");
       this._showPrompt();
     } else if (data === "\x0c") {
       w("\x1b[2J\x1b[H");
       this._showPrompt();
+      w(this._line);
+      if (this._cursor < this._line.length) {
+        w(`\x1b[${this._line.length - this._cursor}D`);
+      }
     } else if (data.length === 1 && data >= " ") {
-      this._line += data;
-      w(data);
+      const tail = this._line.slice(this._cursor);
+      this._line = this._line.slice(0, this._cursor) + data + tail;
+      this._cursor++;
+      if (tail.length === 0) {
+        w(data);
+      } else {
+        w(data + tail + "\x1b[K");
+        w(`\x1b[${tail.length}D`);
+      }
     }
   }
 

--- a/apps/docs/src/components/docs-chat.tsx
+++ b/apps/docs/src/components/docs-chat.tsx
@@ -367,6 +367,10 @@ class ChatShell {
         w(data + tail + "\x1b[K");
         w(`\x1b[${tail.length}D`);
       }
+    } else if (data.length > 1) {
+      for (const ch of data) {
+        await this.handleInput(ch);
+      }
     }
   }
 

--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -1,6 +1,6 @@
 # Local Shell Example
 
-Full local terminal in the browser, connected to your machine's shell via WebSocket and [node-pty](https://github.com/nicolo-ribaudo/just-bash).
+Full local terminal in the browser, connected to your machine's shell via WebSocket and [node-pty](https://github.com/microsoft/node-pty).
 
 ## Setup
 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,6 +1,6 @@
 # Next.js Example
 
-In-browser terminal running [just-bash](https://github.com/nicolo-ribaudo/just-bash) — no backend required. Includes theme switching and a virtual filesystem.
+In-browser terminal running [just-bash](https://github.com/vercel-labs/just-bash) — no backend required. Includes theme switching and a virtual filesystem.
 
 ## Setup
 

--- a/packages/@wterm/dom/src/input.ts
+++ b/packages/@wterm/dom/src/input.ts
@@ -143,6 +143,15 @@ export class InputHandler {
       if (e.key === "Backspace") {
         e.preventDefault();
         this.onData("\x15");
+      } else if (e.key === "a") {
+        e.preventDefault();
+        const sel = window.getSelection();
+        if (sel) {
+          const range = document.createRange();
+          range.selectNodeContents(this.element);
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
       }
       return;
     }

--- a/packages/@wterm/dom/src/input.ts
+++ b/packages/@wterm/dom/src/input.ts
@@ -136,8 +136,7 @@ export class InputHandler {
       if (sel && sel.toString().length > 0) return;
     }
     if ((e.metaKey || e.ctrlKey) && e.key === "v") {
-      e.preventDefault();
-      this.readClipboard();
+      this.textarea.focus();
       return;
     }
     if (e.metaKey && !e.ctrlKey) {
@@ -156,19 +155,8 @@ export class InputHandler {
   private handlePaste(e: ClipboardEvent): void {
     e.preventDefault();
     const text = e.clipboardData?.getData("text");
-    if (text) this.emitPaste(text);
-  }
+    if (!text) return;
 
-  private readClipboard(): void {
-    if (navigator.clipboard?.readText) {
-      navigator.clipboard.readText().then(
-        (text) => { if (text) this.emitPaste(text); },
-        () => {},
-      );
-    }
-  }
-
-  private emitPaste(text: string): void {
     const bridge = this.getBridge();
     if (bridge && bridge.bracketedPaste()) {
       this.onData("\x1b[200~" + text + "\x1b[201~");

--- a/packages/@wterm/dom/src/input.ts
+++ b/packages/@wterm/dom/src/input.ts
@@ -53,6 +53,8 @@ export class InputHandler {
   private _onCompositionStart: () => void;
   private _onCompositionEnd: (e: CompositionEvent) => void;
   private _onInput: () => void;
+  private _onFocus: () => void;
+  private _onBlur: () => void;
 
   constructor(
     element: HTMLElement,
@@ -95,6 +97,8 @@ export class InputHandler {
     this._onCompositionStart = this.handleCompositionStart.bind(this);
     this._onCompositionEnd = this.handleCompositionEnd.bind(this);
     this._onInput = this.handleInput.bind(this);
+    this._onFocus = () => this.element.classList.add("focused");
+    this._onBlur = () => this.element.classList.remove("focused");
 
     this.textarea.addEventListener("keydown", this._onKeyDown);
     this.textarea.addEventListener("paste", this._onPaste as EventListener);
@@ -107,6 +111,8 @@ export class InputHandler {
       this._onCompositionEnd as EventListener,
     );
     this.textarea.addEventListener("input", this._onInput);
+    this.textarea.addEventListener("focus", this._onFocus);
+    this.textarea.addEventListener("blur", this._onBlur);
   }
 
   focus(): void {
@@ -125,6 +131,9 @@ export class InputHandler {
       this._onCompositionEnd as EventListener,
     );
     this.textarea.removeEventListener("input", this._onInput);
+    this.textarea.removeEventListener("focus", this._onFocus);
+    this.textarea.removeEventListener("blur", this._onBlur);
+    this.element.classList.remove("focused");
     this.textarea.remove();
   }
 

--- a/packages/@wterm/dom/src/input.ts
+++ b/packages/@wterm/dom/src/input.ts
@@ -136,7 +136,13 @@ export class InputHandler {
       if (sel && sel.toString().length > 0) return;
     }
     if ((e.metaKey || e.ctrlKey) && e.key === "v") return;
-    if (e.metaKey && !e.ctrlKey) return;
+    if (e.metaKey && !e.ctrlKey) {
+      if (e.key === "Backspace") {
+        e.preventDefault();
+        this.onData("\x15");
+      }
+      return;
+    }
 
     e.preventDefault();
     const seq = this.keyToSequence(e);

--- a/packages/@wterm/dom/src/input.ts
+++ b/packages/@wterm/dom/src/input.ts
@@ -135,7 +135,11 @@ export class InputHandler {
       const sel = window.getSelection();
       if (sel && sel.toString().length > 0) return;
     }
-    if ((e.metaKey || e.ctrlKey) && e.key === "v") return;
+    if ((e.metaKey || e.ctrlKey) && e.key === "v") {
+      e.preventDefault();
+      this.readClipboard();
+      return;
+    }
     if (e.metaKey && !e.ctrlKey) {
       if (e.key === "Backspace") {
         e.preventDefault();
@@ -152,8 +156,19 @@ export class InputHandler {
   private handlePaste(e: ClipboardEvent): void {
     e.preventDefault();
     const text = e.clipboardData?.getData("text");
-    if (!text) return;
+    if (text) this.emitPaste(text);
+  }
 
+  private readClipboard(): void {
+    if (navigator.clipboard?.readText) {
+      navigator.clipboard.readText().then(
+        (text) => { if (text) this.emitPaste(text); },
+        () => {},
+      );
+    }
+  }
+
+  private emitPaste(text: string): void {
     const bridge = this.getBridge();
     if (bridge && bridge.bracketedPaste()) {
       this.onData("\x1b[200~" + text + "\x1b[201~");

--- a/packages/@wterm/dom/src/terminal.css
+++ b/packages/@wterm/dom/src/terminal.css
@@ -64,11 +64,17 @@
 }
 
 .term-cursor {
-  background: var(--term-cursor);
-  color: var(--term-bg);
+  outline: 1px solid var(--term-cursor);
+  outline-offset: -1px;
 }
 
-.wterm.cursor-blink .term-cursor {
+.wterm.focused .term-cursor {
+  background: var(--term-cursor);
+  color: var(--term-bg);
+  outline: none;
+}
+
+.wterm.focused.cursor-blink .term-cursor {
   animation: cursor-blink 1s step-end infinite;
 }
 

--- a/packages/@wterm/just-bash/README.md
+++ b/packages/@wterm/just-bash/README.md
@@ -1,6 +1,6 @@
 # @wterm/just-bash
 
-Shell adapter for [wterm](https://github.com/vercel-labs/wterm), powered by [just-bash](https://github.com/nicolo-ribaudo/just-bash). Provides line editing, tab completion, command history, and a colored prompt — all running in the browser with no backend.
+Shell adapter for [wterm](https://github.com/vercel-labs/wterm), powered by [just-bash](https://github.com/vercel-labs/just-bash). Provides line editing, tab completion, command history, and a colored prompt — all running in the browser with no backend.
 
 ## Install
 

--- a/packages/@wterm/just-bash/src/index.ts
+++ b/packages/@wterm/just-bash/src/index.ts
@@ -22,6 +22,7 @@ export class BashShell {
   private _cwd: string;
   private _line = "";
   private _cursor = 0;
+  private _buffer = "";
   private _history: string[] = [];
   private _historyPos = -1;
   private _busy = false;
@@ -82,10 +83,19 @@ export class BashShell {
     }
 
     if (data === "\r") {
-      const cmd = this._line;
+      const cur = this._line;
       this._line = "";
       this._cursor = 0;
       write("\r\n");
+
+      if (cur.endsWith("\\")) {
+        this._buffer += cur.slice(0, -1) + "\n";
+        write("> ");
+        return;
+      }
+
+      const cmd = this._buffer + cur;
+      this._buffer = "";
 
       if (cmd.trim() && this._bash) {
         this._history.push(cmd);
@@ -180,6 +190,7 @@ export class BashShell {
     } else if (data === "\x03") {
       this._line = "";
       this._cursor = 0;
+      this._buffer = "";
       write("^C\r\n");
       write(this._prompt(this._cwd));
     } else if (data === "\x0c") {

--- a/packages/@wterm/just-bash/src/index.ts
+++ b/packages/@wterm/just-bash/src/index.ts
@@ -160,6 +160,13 @@ export class BashShell {
         this._cursor++;
         write("\x1b[C");
       }
+    } else if (data === "\x15") {
+      if (this._line.length > 0) {
+        if (this._cursor > 0) write(`\x1b[${this._cursor}D`);
+        write("\x1b[K");
+        this._line = "";
+        this._cursor = 0;
+      }
     } else if (data === "\x01") {
       if (this._cursor > 0) {
         write(`\x1b[${this._cursor}D`);

--- a/packages/@wterm/just-bash/src/index.ts
+++ b/packages/@wterm/just-bash/src/index.ts
@@ -160,6 +160,16 @@ export class BashShell {
         this._cursor++;
         write("\x1b[C");
       }
+    } else if (data === "\x01") {
+      if (this._cursor > 0) {
+        write(`\x1b[${this._cursor}D`);
+        this._cursor = 0;
+      }
+    } else if (data === "\x05") {
+      if (this._cursor < this._line.length) {
+        write(`\x1b[${this._line.length - this._cursor}C`);
+        this._cursor = this._line.length;
+      }
     } else if (data === "\x03") {
       this._line = "";
       this._cursor = 0;

--- a/packages/@wterm/just-bash/src/index.ts
+++ b/packages/@wterm/just-bash/src/index.ts
@@ -21,6 +21,7 @@ export class BashShell {
   private _write: ((data: string) => void) | null = null;
   private _cwd: string;
   private _line = "";
+  private _cursor = 0;
   private _history: string[] = [];
   private _historyPos = -1;
   private _busy = false;
@@ -83,6 +84,7 @@ export class BashShell {
     if (data === "\r") {
       const cmd = this._line;
       this._line = "";
+      this._cursor = 0;
       write("\r\n");
 
       if (cmd.trim() && this._bash) {
@@ -117,9 +119,12 @@ export class BashShell {
 
       write(this._prompt(this._cwd));
     } else if (data === "\x7f" || data === "\b") {
-      if (this._line.length > 0) {
-        this._line = this._line.slice(0, -1);
-        write("\b \b");
+      if (this._cursor > 0) {
+        const tail = this._line.slice(this._cursor);
+        this._line = this._line.slice(0, this._cursor - 1) + tail;
+        this._cursor--;
+        write("\b" + tail + "\x1b[K");
+        if (tail.length > 0) write(`\x1b[${tail.length}D`);
       }
     } else if (data === "\x1b[A") {
       if (!this._history.length) return;
@@ -129,6 +134,7 @@ export class BashShell {
         const entry = this._history[this._historyPos];
         write(`\r${this._prompt(this._cwd)}\x1b[K${entry}`);
         this._line = entry;
+        this._cursor = entry.length;
       }
     } else if (data === "\x1b[B") {
       if (this._historyPos < 0) return;
@@ -137,21 +143,45 @@ export class BashShell {
         this._historyPos = -1;
         write(`\r${this._prompt(this._cwd)}\x1b[K`);
         this._line = "";
+        this._cursor = 0;
       } else {
         const entry = this._history[this._historyPos];
         write(`\r${this._prompt(this._cwd)}\x1b[K${entry}`);
         this._line = entry;
+        this._cursor = entry.length;
+      }
+    } else if (data === "\x1b[D") {
+      if (this._cursor > 0) {
+        this._cursor--;
+        write("\x1b[D");
+      }
+    } else if (data === "\x1b[C") {
+      if (this._cursor < this._line.length) {
+        this._cursor++;
+        write("\x1b[C");
       }
     } else if (data === "\x03") {
       this._line = "";
+      this._cursor = 0;
       write("^C\r\n");
       write(this._prompt(this._cwd));
     } else if (data === "\x0c") {
       write("\x1b[2J\x1b[H");
       write(this._prompt(this._cwd));
+      write(this._line);
+      if (this._cursor < this._line.length) {
+        write(`\x1b[${this._line.length - this._cursor}D`);
+      }
     } else if (data.length === 1 && data >= " ") {
-      this._line += data;
-      write(data);
+      const tail = this._line.slice(this._cursor);
+      this._line = this._line.slice(0, this._cursor) + data + tail;
+      this._cursor++;
+      if (tail.length === 0) {
+        write(data);
+      } else {
+        write(data + tail + "\x1b[K");
+        write(`\x1b[${tail.length}D`);
+      }
     }
   }
 
@@ -220,6 +250,7 @@ export class BashShell {
       const completion = candidates[0].slice(prefix.length);
       if (completion) {
         this._line += completion;
+        this._cursor += completion.length;
         write(completion);
       }
       try {
@@ -231,6 +262,7 @@ export class BashShell {
         );
         if (stat.stdout?.trim() === "DIR" && !this._line.endsWith("/")) {
           this._line += "/";
+          this._cursor++;
           write("/");
         }
       } catch {
@@ -246,6 +278,7 @@ export class BashShell {
       const partialCompletion = common.slice(prefix.length);
       if (partialCompletion) {
         this._line += partialCompletion;
+        this._cursor += partialCompletion.length;
         write(partialCompletion);
       } else {
         write("\r\n");

--- a/packages/@wterm/just-bash/src/index.ts
+++ b/packages/@wterm/just-bash/src/index.ts
@@ -210,6 +210,10 @@ export class BashShell {
         write(data + tail + "\x1b[K");
         write(`\x1b[${tail.length}D`);
       }
+    } else if (data.length > 1) {
+      for (const ch of data) {
+        await this.handleInput(ch);
+      }
     }
   }
 

--- a/packages/@wterm/just-bash/src/index.ts
+++ b/packages/@wterm/just-bash/src/index.ts
@@ -89,7 +89,7 @@ export class BashShell {
       write("\r\n");
 
       if (cur.endsWith("\\")) {
-        this._buffer += cur.slice(0, -1) + "\n";
+        this._buffer += cur + "\n";
         write("> ");
         return;
       }


### PR DESCRIPTION
## Summary

- **Arrow keys & cursor movement**: Add left/right arrow, Ctrl+A (home), Ctrl+E (end) support to `BashShell` and `ChatShell` with full cursor position tracking for mid-line editing, insertion, and deletion
- **Cmd+Backspace**: Wire Cmd+Backspace through the DOM input layer as `\x15` and handle it in both shells to clear the entire line
- **Line continuation**: Support trailing `\` for multi-line commands in `BashShell`, with `> ` continuation prompt and Ctrl+C to cancel
- **Paste**: Fix multi-character input (paste) being silently dropped by the `data.length === 1` guard in both shells — now iterates each character
- **Cmd+A**: Select all visible terminal content instead of the hidden textarea
- **Cursor focus state**: Track textarea focus/blur and toggle a `focused` class on the terminal element — filled caret when focused, outline when not; blink only when focused