### PR TITLE
prepare v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,25 @@
 # Changelog
 
-## 0.1.5
+## 0.1.6
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- Fixed **terminal height** — replaced `maxHeight` with deterministic `height` computed from `rows * rowHeight`, preventing layout drift caused by `getBoundingClientRect()` timing
+- Fixed **border rendering** — switched docs terminal borders from CSS `border` to `inset box-shadow` to avoid border-width interference with height calculations
+
+### Improvements
+
+- **Row height variable** — added `--term-row-height` CSS custom property so row and block heights are defined in one place
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.1.5
 
 ### Bug Fixes
 
@@ -19,8 +36,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.1.4
 

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Headless terminal emulator core for the web — WASM bridge and WebSocket transport",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/dom",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "DOM renderer, input handler, and orchestrator for wterm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/just-bash",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "just-bash shell adapter for wterm — line editing, tab completion, history, prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/markdown",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Streaming markdown-to-ANSI renderer for wterm terminals",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/react",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "React component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps all `@wterm/*` packages to **0.1.6**
- Fixes deterministic terminal height using `rows * rowHeight` instead of `getBoundingClientRect()`
- Adds `--term-row-height` CSS custom property for consistent row sizing
- Switches docs terminal borders from CSS `border` to inset `box-shadow`

## Changelog

### Bug Fixes

- Fixed **terminal height** — replaced `maxHeight` with deterministic `height` computed from `rows * rowHeight`, preventing layout drift caused by `getBoundingClientRect()` timing
- Fixed **border rendering** — switched docs terminal borders from CSS `border` to `inset box-shadow` to avoid border-width interference with height calculations

### Improvements

- **Row height variable** — added `--term-row-height` CSS custom property so row and block heights are defined in one place