### PR TITLE
chore: add nitro example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ cp web/wterm.wasm examples/nextjs/public/
 pnpm --filter nextjs dev
 ```
 
+### Run the Nitro example
+
+Full terminal running on real PTYs (via [zigpty](https://github.com/pithings/zigpty)) allocated by a [Nitro](https://nitro.build) backend — each in-app tab is a named session multiplexed to every browser attached to it.
+
+```bash
+pnpm --filter nitro-example dev
+```
+
+See [examples/nitro/README.md](examples/nitro/README.md) for details.
+
 ### Run Zig tests
 
 ```bash

--- a/apps/docs/src/lib/docs-navigation.ts
+++ b/apps/docs/src/lib/docs-navigation.ts
@@ -46,6 +46,11 @@ export const navGroups: NavGroup[] = [
         href: `${GITHUB}/tree/main/examples/local`,
         external: true,
       },
+      {
+        name: "Nitro",
+        href: `${GITHUB}/tree/main/examples/nitro`,
+        external: true,
+      },
     ],
   },
   {

--- a/examples/nitro/.gitignore
+++ b/examples/nitro/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.data
+.nitro
+.cache
+.output
+.env
+.env.local

--- a/examples/nitro/AGENTS.md
+++ b/examples/nitro/AGENTS.md
@@ -1,0 +1,37 @@
+This project is based on [Nitro](https://nitro.build) v3, [h3](https://h3.dev/), [Vite](https://vite.dev/) and [rolldown](https://rolldown.rs/).
+
+## Project Structure
+
+`app/` is the frontend (SPA/SSR) with `index.html` as entry. `server/` contains server-side code with subdirs: `api/` (/api prefixed handlers), `routes/` (non-prefixed route handlers), `middleware/`, `plugins/`, `utils/`, `assets/`, and `tasks/`. `public/` holds static assets (copied, not bundled). Config files: `vite.config.ts` (loads nitro/vite plugin), `nitro.config.ts` (serverDir, routeRules, preset, etc.), `tsconfig.json` (extends nitro/tsconfig, `~/*` path alias).
+
+## Conventions
+
+- Path alias `~/*` (tsconfig), use explicit `.ts` extensions
+- Route handlers use `defineHandler()` from `nitro`
+- Route file patterns: `[param]` for dynamic, `[...slug]` for catch-all, `.get.ts`/`.post.ts` for method-specific, `(group)/` ignored in path
+
+## Nitro Quick Reference
+
+> Use `npx nitro docs` and `npx nitro docs --page` to read the nitro docs.
+
+**`nitro`** — `defineConfig`, `defineHandler`, `defineMiddleware`, `defineWebSocketHandler`, `definePlugin` (hooks: `request`, `response`, `error`, `close`), `defineRouteMeta`, `defineErrorHandler`, `html`, `HTTPError`, `HTTPResponse`, `fetch`, `serverFetch`
+**`nitro/h3`** — All h3 utilities (re-exported)
+**`nitro/app`** — `useNitroApp()`, `useNitroHooks()`, `getRouteRules()`, `serverFetch()`, `fetch()`
+**`nitro/cache`** — `defineCachedHandler(handler, opts)`, `defineCachedFunction(fn, opts)` (GET/HEAD only)
+**`nitro/context`** — `useRequest()` (experimental, requires async context)
+**`nitro/runtime-config`** — `useRuntimeConfig()`
+**`nitro/storage`** — `useStorage(namespace?)` — KV (`getItem`, `setItem`, `removeItem`, `getKeys`)
+**`nitro/database`** — `useDatabase()` — SQL via `` db.sql`SELECT ...` `` (requires `experimental: { database: true }`)
+**`nitro/task`** — `defineTask({ meta, run })`, `runTask(name, { payload })` (requires `experimental: { tasks: true }`)
+**`nitro/vite`** — `nitro()` Vite plugin (used in `vite.config.ts`)
+**`nitro/vite/runtime`** — `fetchViteEnv()`
+**`nitro/types`** — TypeScript type definitions
+
+**Request Lifecycle:** Plugins `request` hook → Static assets → Route rules → Global middleware → Route-scoped middleware → Route handler → Server entry fallback → Renderer (SPA/SSR) → Plugins `response` hook
+
+**Config (`nitro.config.ts`):** `routeRules` (per-route headers, redirects, proxy, cache, basicAuth), `$development` / `$production` (env-specific), `storage` + `devStorage` (KV drivers), `prerender: { routes, crawlLinks }`, `traceDeps` (externalize bundler-incompatible deps)
+
+**`import.meta.*` flags:** `dev`, `preset`, `prerender`, `nitro`, `server`, `client`, `baseURL`
+
+**Nitro v3 / H3 v2 migration:** `nitropack/runtime/*` → `nitro/*` (e.g. `nitro/storage`, `nitro/task`, `nitro/types`); all h3 imports from `nitro/h3`; `eventHandler()`/`defineEventHandler()` → `defineHandler()`; `createError()`/`H3Error` → `HTTPError`; `event.path` → `event.url.pathname`; `event.web` → `event.req` (native `Request`); body via `event.req.json()`/`.text()`/`.formData()`; headers via `event.req.headers.get()`/`event.res.headers.set()`; status via `event.res.status`; always `return` values (`return redirect(loc, code)`); `sendError()` → `throw HTTPError`; `sendNoContent()` → `return noContent()`; `useAppConfig()` removed.
+

--- a/examples/nitro/CLAUDE.md
+++ b/examples/nitro/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/examples/nitro/README.md
+++ b/examples/nitro/README.md
@@ -1,0 +1,31 @@
+# Nitro Example
+
+Full terminal running on real PTYs allocated by a [Nitro](https://nitro.build) backend. Each **in-app tab** is a named session (`/_ws?id=...`); the server lazily spawns one PTY per session id with [zigpty](https://github.com/pithings/zigpty) and multiplexes it to every browser window attached to that id — so opening the same session id in two browser tabs shares a shell, while hitting the `+` button spawns a fresh one. Theme switching included.
+
+## Setup
+
+From the monorepo root:
+
+```bash
+pnpm install
+zig build
+pnpm --filter nitro-example dev
+```
+
+## How It Works
+
+- `@wterm/dom` renders the terminal — plain TS, no framework
+- Nitro WebSocket route (`/terminal`) lazily allocates one shared PTY with `zigpty`
+- Every peer writes to the same PTY and receives a broadcast of its output
+- Keystrokes flow browser → WS → PTY; PTY output flows back to all peers
+- Resize is forwarded with an inline `\x1b[RESIZE:cols;rows]` control sequence
+- Theme selector switches between Default, Solarized Dark, Monokai, and Light
+
+## Key Files
+
+| File | Description |
+|---|---|
+| `app/entry-client.ts` | Client entry: terminal + WebSocket wiring |
+| `terminal.ts` | WebSocket handler: single shared PTY per session id, broadcasts to all peers |
+| `vite.config.ts` | Vite + Nitro plugin |
+| `nitro.config.ts` | Nitro config (`features.websocket`, registers `/terminal` route) |

--- a/examples/nitro/README.md
+++ b/examples/nitro/README.md
@@ -1,6 +1,6 @@
 # Nitro Example
 
-Full terminal running on real PTYs allocated by a [Nitro](https://nitro.build) backend. Each **in-app tab** is a named session (`/_ws?id=...`); the server lazily spawns one PTY per session id with [zigpty](https://github.com/pithings/zigpty) and multiplexes it to every browser window attached to that id — so opening the same session id in two browser tabs shares a shell, while hitting the `+` button spawns a fresh one. Theme switching included.
+Full terminal running on real PTYs allocated by a [Nitro](https://nitro.build) backend. Each in-app tab is a named session — the server spawns one PTY per session id via [zigpty](https://github.com/pithings/zigpty) and multiplexes it across every connected browser, so opening a second window mirrors all existing sessions (input, output, tabs, lifecycle) live. Theme switching included.
 
 ## Setup
 
@@ -15,17 +15,23 @@ pnpm --filter nitro-example dev
 ## How It Works
 
 - `@wterm/dom` renders the terminal — plain TS, no framework
-- Nitro WebSocket route (`/terminal`) lazily allocates one shared PTY with `zigpty`
-- Every peer writes to the same PTY and receives a broadcast of its output
-- Keystrokes flow browser → WS → PTY; PTY output flows back to all peers
-- Resize is forwarded with an inline `\x1b[RESIZE:cols;rows]` control sequence
+- Nitro WebSocket route (`/terminal`) owns a `Map<sid, Session>` of shared PTYs
+- On connect, the server sends a `tabs` sync message listing all live session ids; the client attaches an xterm to each
+- `opened` / `closed` broadcasts keep every browser's tab bar in sync across windows
+- Keystrokes flow browser → WS → PTY; PTY output fans out to all peers
+- Per-session stats (pid, cwd, cpu%, rss, proc count, foreground proc) are sampled every second and broadcast
 - Theme selector switches between Default, Solarized Dark, Monokai, and Light
+
+## WebSocket Protocol
+
+Client → server: `open`, `close`, `input`, `resize`, `rerender` (each carries a `sid`).
+Server → client: `tabs` (initial sync), `opened`, `closed`, `data`, `stats`, `error`.
 
 ## Key Files
 
 | File | Description |
 |---|---|
-| `app/entry-client.ts` | Client entry: terminal + WebSocket wiring |
-| `terminal.ts` | WebSocket handler: single shared PTY per session id, broadcasts to all peers |
+| `app/entry-client.ts` | Client entry: tabs, terminal, WebSocket sync |
+| `terminal.ts` | WebSocket handler: PTY-per-session map, broadcasts to all peers |
 | `vite.config.ts` | Vite + Nitro plugin |
 | `nitro.config.ts` | Nitro config (`features.websocket`, registers `/terminal` route) |

--- a/examples/nitro/app/assets/main.css
+++ b/examples/nitro/app/assets/main.css
@@ -1,0 +1,287 @@
+:root {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color-scheme: light dark;
+  color: #e6e6e6;
+  background: #1a1a1a;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  max-width: min(1400px, 100vw);
+  width: 100%;
+  margin: 0 auto;
+}
+
+.window {
+  min-width: 0;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.toolbar h1 {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.toolbar .logo {
+  height: 1.75rem;
+  width: auto;
+}
+
+.theme-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #a0a0a0;
+}
+
+.theme-select select {
+  background: #2a2a2a;
+  color: inherit;
+  border: 1px solid #3a3a3a;
+  border-radius: 6px;
+  padding: 0.35rem 0.6rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+/* macOS-style window */
+.window {
+  border-radius: 10px;
+  overflow: hidden;
+  background: #1e1e1e;
+  border: 1px solid #000;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset,
+    0 10px 40px rgba(0, 0, 0, 0.5),
+    0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.titlebar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0 0.75rem;
+  height: 38px;
+  background: linear-gradient(#3a3a3a, #2d2d2d);
+  border-bottom: 1px solid #000;
+  position: relative;
+}
+
+.traffic-lights {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.light {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+  box-shadow: 0 0 1px rgba(255, 255, 255, 0.15) inset;
+}
+
+.light.close { background: #ff5f57; }
+.light.minimize { background: #febc2e; }
+.light.maximize { background: #28c840; }
+
+.tabs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  height: 100%;
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  height: 26px;
+  background: transparent;
+  color: #a0a0a0;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0 0.4rem 0 0.7rem;
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+  flex-shrink: 0;
+  max-width: 180px;
+}
+
+.tab .tab-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tab:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: #d0d0d0;
+}
+
+.tab.active {
+  background: #1e1e1e;
+  color: #e6e6e6;
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
+}
+
+.tab-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  color: #777;
+  font-size: 0.9rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.tab-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.tab-new {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  background: transparent;
+  color: #a0a0a0;
+  border: none;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 1rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.tab-new:hover {
+  color: #e6e6e6;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+#terminal {
+  height: 80vh;
+  position: relative;
+  background: #1e1e1e;
+  padding: 0.5rem;
+  overflow: hidden;
+}
+
+#terminal .terminal-mount {
+  height: 100%;
+}
+
+.statusbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 24px;
+  margin-top: -1rem;
+  padding: 0 0.75rem;
+  background: #181818;
+  border: 1px solid #000;
+  border-radius: 8px;
+  color: #888;
+  font-size: 0.72rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.statusbar .status-cwd {
+  color: #b0b0b0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.statusbar .status-sep {
+  color: #444;
+  flex-shrink: 0;
+}
+
+.statusbar .status-item {
+  flex-shrink: 0;
+}
+
+
+@media (prefers-color-scheme: light) {
+  .statusbar {
+    background: #ececec;
+    border-top-color: rgba(0, 0, 0, 0.15);
+    color: #666;
+  }
+  .statusbar .status-cwd { color: #333; }
+  .statusbar .status-sep { color: #bbb; }
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #1a1a1a;
+    background: #fafafa;
+  }
+  .theme-select select {
+    background: #fff;
+    border-color: #ddd;
+  }
+  .theme-select {
+    color: #666;
+  }
+  .window {
+    background: #f6f6f6;
+    border-color: rgba(0, 0, 0, 0.18);
+  }
+  .titlebar {
+    background: linear-gradient(#e8e8e8, #d7d7d7);
+    border-bottom-color: rgba(0, 0, 0, 0.15);
+  }
+  .tab { color: #555; }
+  .tab:hover { background: rgba(0, 0, 0, 0.05); color: #222; }
+  .tab.active {
+    background: #f6f6f6;
+    color: #1a1a1a;
+    border-color: rgba(0, 0, 0, 0.08);
+  }
+  .tab-close { color: #777; }
+  .tab-close:hover { background: rgba(0, 0, 0, 0.1); color: #000; }
+  .tab-new { color: #666; }
+  .tab-new:hover { background: rgba(0, 0, 0, 0.06); color: #000; }
+  #terminal { background: #f6f6f6; }
+}

--- a/examples/nitro/app/assets/nitro.svg
+++ b/examples/nitro/app/assets/nitro.svg
@@ -1,0 +1,43 @@
+
+<!-- nitro logo -->
+<svg width="40" height="40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0_115_108)">
+    <path fill-rule="evenodd" clip-rule="evenodd"
+      d="M35.2166 7.02016C28.0478 -1.38317 15.4241 -2.38397 7.02077 4.78481C-1.38256 11.9536 -2.38336 24.5773 4.78542 32.9806C11.9542 41.3839 24.5779 42.3847 32.9812 35.216C41.3846 28.0472 42.3854 15.4235 35.2166 7.02016ZM25.2525 17.5175C26.0233 17.5175 26.5155 18.3527 26.1287 19.0194L26.0175 19.2111L18.4696 31.6294C18.3293 31.8602 18.0788 32.001 17.8088 32.001H17.0883C16.5946 32.001 16.2336 31.5349 16.3573 31.0569L18.4054 23.1384C18.5691 22.5053 18.0912 21.888 17.4373 21.888H14.2914C13.6375 21.888 13.1596 21.2708 13.3232 20.6377L16.4137 8.68289C16.5261 8.28056 16.8904 7.99734 17.3081 8.00208C17.3587 8.00266 17.4046 8.0035 17.4427 8.0047L20.6109 8.00465C21.217 8.00436 21.684 8.53896 21.6023 9.13949L21.5828 9.28246L20.3746 16.349C20.2702 16.9598 20.7406 17.5175 21.3603 17.5175H25.2525Z"
+      fill="url(#paint0_diamond_115_108)" />
+    <mask id="mask0_115_108" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0"
+      width="40" height="41">
+      <circle cx="20" cy="20.001" r="20" fill="url(#paint1_diamond_115_108)" />
+    </mask>
+    <g mask="url(#mask0_115_108)">
+      <g filter="url(#filter0_f_115_108)">
+        <path
+          d="M1.11145 13.4267C0.0703174 16.4179 -0.245523 19.6136 0.189923 22.7507C0.62537 25.8879 1.79965 28.8768 3.61611 31.4713C5.43256 34.0659 7.83925 36.192 10.6381 37.6746C13.4369 39.1572 16.5478 39.9538 19.7147 39.999C22.8816 40.0442 26.0139 39.3366 28.8539 37.9345C31.6939 36.5324 34.1602 34.4758 36.05 31.9341C37.9397 29.3924 39.1988 26.4383 39.7236 23.3148C40.2483 20.1914 40.0238 16.9879 39.0684 13.9682L33.2532 15.808C33.9172 17.9068 34.0732 20.1333 33.7085 22.3042C33.3438 24.4751 32.4687 26.5283 31.1552 28.2949C29.8418 30.0615 28.1276 31.4908 26.1537 32.4653C24.1799 33.4399 22.0028 33.9316 19.8017 33.9002C17.6006 33.8688 15.4384 33.3151 13.4932 32.2847C11.5479 31.2543 9.87518 29.7766 8.61269 27.9733C7.35019 26.1699 6.53403 24.0926 6.23138 21.9122C5.92873 19.7317 6.14825 17.5106 6.87187 15.4316L1.11145 13.4267Z"
+          fill="white" />
+      </g>
+    </g>
+  </g>
+  <defs>
+    <filter id="filter0_f_115_108" x="-10" y="3.42667" width="60" height="46.5744"
+      filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+      <feGaussianBlur stdDeviation="5" result="effect1_foregroundBlur_115_108" />
+    </filter>
+    <radialGradient id="paint0_diamond_115_108" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(4.00069 20.0004) scale(39.0007 397.71)">
+      <stop stop-color="#31B2F3" />
+      <stop offset="0.473958" stop-color="#F27CEC" />
+      <stop offset="1" stop-color="#FD6641" />
+    </radialGradient>
+    <radialGradient id="paint1_diamond_115_108" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(4 20.0011) scale(39 397.703)">
+      <stop stop-color="#F27CEC" />
+      <stop offset="0.484375" stop-color="#31B2F3" />
+      <stop offset="1" stop-color="#7D7573" />
+    </radialGradient>
+    <clipPath id="clip0_115_108">
+      <rect width="146" height="40.001" fill="white" />
+    </clipPath>
+  </defs>
+</svg>

--- a/examples/nitro/app/entry-client.ts
+++ b/examples/nitro/app/entry-client.ts
@@ -1,0 +1,327 @@
+import { WTerm } from "@wterm/dom";
+import "@wterm/dom/css";
+
+const terminalHost = document.querySelector<HTMLElement>("#terminal")!;
+const tabsHost = document.querySelector<HTMLElement>("#tabs")!;
+const newTabBtn = document.querySelector<HTMLButtonElement>("#new-tab")!;
+const themeSelect = document.querySelector<HTMLSelectElement>("#theme")!;
+const statusCwd = document.querySelector<HTMLElement>("#status-cwd")!;
+const statusPid = document.querySelector<HTMLElement>("#status-pid")!;
+const statusProc = document.querySelector<HTMLElement>("#status-proc")!;
+const statusCpu = document.querySelector<HTMLElement>("#status-cpu")!;
+const statusMem = document.querySelector<HTMLElement>("#status-mem")!;
+const statusProcs = document.querySelector<HTMLElement>("#status-procs")!;
+
+interface Stats {
+  pid: number;
+  cwd: string | null;
+  rssBytes: number;
+  cpuPct: number;
+  count: number;
+  proc: string;
+}
+
+function prettyCwd(cwd: string | null): string {
+  if (!cwd) return "–";
+  const m = cwd.match(/^\/home\/[^/]+/);
+  if (m && cwd.startsWith(m[0])) return "~" + cwd.slice(m[0].length);
+  return cwd;
+}
+
+function cwdBasename(cwd: string | null): string {
+  if (!cwd) return "";
+  const m = cwd.match(/^\/home\/[^/]+$/);
+  if (m) return "~";
+  if (cwd === "/") return "/";
+  const parts = cwd.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? "/";
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+interface Tab {
+  id: string;
+  mount: HTMLElement;
+  term: WTerm;
+  tabEl: HTMLElement;
+  labelEl: HTMLElement;
+  lastCols: number;
+  lastRows: number;
+  stats: Stats | null;
+  opened: boolean;
+}
+
+const tabs: Tab[] = [];
+let activeId: string | null = null;
+let tabCounter = 0;
+
+const THEME_CLASSES = ["theme-solarized-dark", "theme-monokai", "theme-light"];
+
+function applyTheme(el: HTMLElement, value: string) {
+  for (const c of THEME_CLASSES) el.classList.remove(c);
+  if (value) el.classList.add(value);
+}
+
+function wsUrl(): string {
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${window.location.host}/terminal`;
+}
+
+let ws: WebSocket;
+const pendingOpens: Array<() => void> = [];
+let wsReady = false;
+
+function sendJSON(data: unknown) {
+  if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(data));
+}
+
+function connect() {
+  ws = new WebSocket(wsUrl());
+  wsReady = false;
+  ws.addEventListener("open", () => {
+    wsReady = true;
+    for (const fn of pendingOpens.splice(0)) fn();
+  });
+  ws.addEventListener("message", async (event) => {
+    const text =
+      typeof event.data === "string" ? event.data : await event.data.text();
+    let msg: any;
+    try {
+      msg = JSON.parse(text);
+    } catch {
+      return;
+    }
+    if (!msg || typeof msg !== "object") return;
+    handleServerMessage(msg);
+  });
+  ws.addEventListener("close", () => {
+    for (const t of tabs) t.term.write("\r\n\x1b[90m[disconnected]\x1b[0m\r\n");
+  });
+}
+
+function handleServerMessage(msg: any) {
+  switch (msg.type) {
+    case "tabs": {
+      return;
+    }
+    case "opened": {
+      const tab = tabs.find((t) => t.id === msg.sid);
+      if (tab) tab.opened = true;
+      return;
+    }
+    case "closed": {
+      const tab = tabs.find((t) => t.id === msg.sid);
+      if (tab) {
+        tab.term.write(
+          `\r\n\x1b[90m[process exited with code ${msg.exitCode}]\x1b[0m\r\n`,
+        );
+      }
+      return;
+    }
+    case "data": {
+      const tab = tabs.find((t) => t.id === msg.sid);
+      if (tab) tab.term.write(msg.data);
+      return;
+    }
+    case "stats": {
+      const tab = tabs.find((t) => t.id === msg.sid);
+      if (!tab) return;
+      tab.stats = {
+        pid: msg.pid,
+        cwd: msg.cwd,
+        rssBytes: msg.rssBytes,
+        cpuPct: msg.cpuPct,
+        count: msg.count,
+        proc: msg.proc,
+      };
+      const label = tab.stats.proc || cwdBasename(tab.stats.cwd);
+      if (label) tab.labelEl.textContent = label;
+      if (activeId === tab.id) renderStatus(tab);
+      return;
+    }
+    case "error": {
+      const tab = tabs.find((t) => t.id === msg.sid);
+      if (tab) tab.term.write(`\r\n\x1b[31m${msg.message}\x1b[0m\r\n`);
+      return;
+    }
+  }
+}
+
+function createTab(idArg?: string): Tab {
+  tabCounter += 1;
+  const id = idArg ?? `session-${tabCounter}-${Date.now()}`;
+  const name = `Session ${tabCounter}`;
+
+  const mount = document.createElement("div");
+  mount.className = "terminal-mount";
+  mount.style.position = "absolute";
+  mount.style.inset = "0";
+  mount.style.visibility = "hidden";
+  terminalHost.appendChild(mount);
+
+  const initialCols = 80;
+  const initialRows = 24;
+
+  const term = new WTerm(mount, {
+    cols: initialCols,
+    rows: initialRows,
+    autoResize: true,
+    onData: (data) => sendJSON({ type: "input", sid: id, data }),
+    onResize: (cols, rows) => {
+      if (activeId !== id) return;
+      if (cols === tab.lastCols && rows === tab.lastRows) return;
+      tab.lastCols = cols;
+      tab.lastRows = rows;
+      sendJSON({ type: "resize", sid: id, cols, rows });
+    },
+    onTitle: (t) => {
+      if (activeId === id) document.title = t;
+    },
+  });
+
+  term.init();
+  applyTheme(mount, themeSelect.value);
+
+  const tabEl = document.createElement("button");
+  tabEl.className = "tab";
+  tabEl.type = "button";
+  const label = document.createElement("span");
+  label.className = "tab-label";
+  label.textContent = name;
+  tabEl.appendChild(label);
+
+  const closeBtn = document.createElement("span");
+  closeBtn.className = "tab-close";
+  closeBtn.setAttribute("role", "button");
+  closeBtn.setAttribute("aria-label", `Close ${name}`);
+  closeBtn.textContent = "×";
+  tabEl.appendChild(closeBtn);
+
+  tabsHost.insertBefore(tabEl, newTabBtn);
+
+  const tab: Tab = {
+    id,
+    mount,
+    term,
+    tabEl,
+    labelEl: label,
+    lastCols: initialCols,
+    lastRows: initialRows,
+    stats: null,
+    opened: false,
+  };
+
+  tabEl.addEventListener("click", (e) => {
+    if (e.target === closeBtn) return;
+    activate(id);
+  });
+  closeBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    closeTab(id);
+  });
+
+  return tab;
+}
+
+function openSession(tab: Tab) {
+  const send = () =>
+    sendJSON({
+      type: "open",
+      sid: tab.id,
+      cols: tab.lastCols,
+      rows: tab.lastRows,
+    });
+  if (wsReady) send();
+  else pendingOpens.push(send);
+}
+
+function renderStatus(tab: Tab | null) {
+  if (!tab || !tab.stats) {
+    statusCwd.textContent = "–";
+    statusProc.textContent = "–";
+    statusPid.textContent = "pid –";
+    statusCpu.textContent = "CPU –";
+    statusMem.textContent = "MEM –";
+    statusProcs.textContent = "– procs";
+    return;
+  }
+  const s = tab.stats;
+  statusCwd.textContent = prettyCwd(s.cwd);
+  statusProc.textContent = s.proc || "–";
+  statusPid.textContent = `pid ${s.pid}`;
+  statusCpu.textContent = `CPU ${s.cpuPct.toFixed(1)}%`;
+  statusMem.textContent = `MEM ${formatBytes(s.rssBytes)}`;
+  statusProcs.textContent = `${s.count} proc${s.count === 1 ? "" : "s"}`;
+}
+
+function activate(id: string) {
+  const prev = activeId;
+  activeId = id;
+  let active: Tab | null = null;
+  for (const t of tabs) {
+    const isActive = t.id === id;
+    t.mount.style.visibility = isActive ? "visible" : "hidden";
+    t.tabEl.classList.toggle("active", isActive);
+    if (isActive) {
+      t.term.focus();
+      active = t;
+    }
+  }
+  renderStatus(active);
+  if (active && prev !== id) {
+    sendJSON({ type: "rerender", sid: active.id });
+  }
+}
+
+function closeTab(id: string) {
+  const idx = tabs.findIndex((t) => t.id === id);
+  if (idx === -1) return;
+  const tab = tabs[idx];
+  sendJSON({ type: "close", sid: id });
+  tab.mount.remove();
+  tab.tabEl.remove();
+  tabs.splice(idx, 1);
+
+  if (activeId === id) {
+    activeId = null;
+    const next = tabs[idx] ?? tabs[idx - 1];
+    if (next) activate(next.id);
+  }
+
+  if (tabs.length === 0) {
+    addTab();
+  }
+}
+
+function addTab() {
+  const t = createTab();
+  tabs.push(t);
+  openSession(t);
+  activate(t.id);
+}
+
+newTabBtn.addEventListener("click", addTab);
+
+window.addEventListener("keydown", (e) => {
+  if (e.ctrlKey && e.shiftKey && (e.key === "T" || e.key === "t")) {
+    e.preventDefault();
+    addTab();
+  }
+});
+
+connect();
+
+// initial tab
+const first = createTab();
+tabs.push(first);
+openSession(first);
+activate(first.id);
+
+themeSelect.addEventListener("change", () => {
+  for (const t of tabs) applyTheme(t.mount, themeSelect.value);
+});

--- a/examples/nitro/app/entry-client.ts
+++ b/examples/nitro/app/entry-client.ts
@@ -107,19 +107,36 @@ function connect() {
 function handleServerMessage(msg: any) {
   switch (msg.type) {
     case "tabs": {
+      const serverIds: string[] = (msg.tabs ?? []).map((t: any) => t.id);
+      for (const sid of serverIds) {
+        if (!tabs.find((t) => t.id === sid)) attachExistingTab(sid);
+      }
+      if (tabs.length === 0) {
+        addTab();
+      } else {
+        if (!activeId) activate(tabs[0].id);
+        if (activeId) sendJSON({ type: "rerender", sid: activeId });
+      }
       return;
     }
     case "opened": {
-      const tab = tabs.find((t) => t.id === msg.sid);
-      if (tab) tab.opened = true;
+      let tab = tabs.find((t) => t.id === msg.sid);
+      if (!tab) tab = attachExistingTab(msg.sid);
+      tab.opened = true;
       return;
     }
     case "closed": {
-      const tab = tabs.find((t) => t.id === msg.sid);
-      if (tab) {
-        tab.term.write(
-          `\r\n\x1b[90m[process exited with code ${msg.exitCode}]\x1b[0m\r\n`,
-        );
+      const idx = tabs.findIndex((t) => t.id === msg.sid);
+      if (idx === -1) return;
+      const tab = tabs[idx];
+      tab.mount.remove();
+      tab.tabEl.remove();
+      tabs.splice(idx, 1);
+      if (activeId === msg.sid) {
+        activeId = null;
+        const next = tabs[idx] ?? tabs[idx - 1];
+        if (next) activate(next.id);
+        else addTab();
       }
       return;
     }
@@ -279,23 +296,7 @@ function activate(id: string) {
 }
 
 function closeTab(id: string) {
-  const idx = tabs.findIndex((t) => t.id === id);
-  if (idx === -1) return;
-  const tab = tabs[idx];
   sendJSON({ type: "close", sid: id });
-  tab.mount.remove();
-  tab.tabEl.remove();
-  tabs.splice(idx, 1);
-
-  if (activeId === id) {
-    activeId = null;
-    const next = tabs[idx] ?? tabs[idx - 1];
-    if (next) activate(next.id);
-  }
-
-  if (tabs.length === 0) {
-    addTab();
-  }
 }
 
 function addTab() {
@@ -303,6 +304,13 @@ function addTab() {
   tabs.push(t);
   openSession(t);
   activate(t.id);
+}
+
+function attachExistingTab(sid: string): Tab {
+  const t = createTab(sid);
+  tabs.push(t);
+  t.opened = true;
+  return t;
 }
 
 newTabBtn.addEventListener("click", addTab);
@@ -315,12 +323,6 @@ window.addEventListener("keydown", (e) => {
 });
 
 connect();
-
-// initial tab
-const first = createTab();
-tabs.push(first);
-openSession(first);
-activate(first.id);
 
 themeSelect.addEventListener("change", () => {
   for (const t of tabs) applyTheme(t.mount, themeSelect.value);

--- a/examples/nitro/index.html
+++ b/examples/nitro/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link rel="icon" type="image/svg+xml" href="/app/assets/nitro.svg" />
+    <title>Nitro wterm</title>
+    <style>
+      @import "~/app/assets/main.css";
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <header class="toolbar">
+        <h1>
+          <img src="/app/assets/nitro.svg" alt="Nitro" class="logo" />
+          <span>Nitro wterm</span>
+        </h1>
+        <label class="theme-select">
+          <span>Theme</span>
+          <select id="theme">
+            <option value="">Default</option>
+            <option value="theme-solarized-dark">Solarized Dark</option>
+            <option value="theme-monokai">Monokai</option>
+            <option value="theme-light">Light</option>
+          </select>
+        </label>
+      </header>
+      <div class="window">
+        <div class="titlebar">
+          <div class="traffic-lights" aria-hidden="true">
+            <span class="light close"></span>
+            <span class="light minimize"></span>
+            <span class="light maximize"></span>
+          </div>
+          <div id="tabs" class="tabs">
+            <button id="new-tab" type="button" class="tab-new" aria-label="New tab">
+              +
+            </button>
+          </div>
+        </div>
+        <div id="terminal"></div>
+      </div>
+      <div id="statusbar" class="statusbar">
+        <span class="status-cwd" id="status-cwd">–</span>
+        <span class="status-sep">·</span>
+        <span class="status-item" id="status-proc">–</span>
+        <span class="status-sep">·</span>
+        <span class="status-item" id="status-pid">pid –</span>
+        <span class="status-sep">·</span>
+        <span class="status-item" id="status-cpu">CPU –</span>
+        <span class="status-sep">·</span>
+        <span class="status-item" id="status-mem">MEM –</span>
+        <span class="status-sep">·</span>
+        <span class="status-item" id="status-procs">– procs</span>
+      </div>
+    </div>
+    <script type="module" src="/app/entry-client.ts"></script>
+  </body>
+</html>

--- a/examples/nitro/nitro.config.ts
+++ b/examples/nitro/nitro.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "nitro";
+
+export default defineConfig({
+  features: {
+    websocket: true,
+  },
+  routes: {
+    "/terminal": "./terminal.ts"
+  }
+});

--- a/examples/nitro/package.json
+++ b/examples/nitro/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nitro-example",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite dev",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "nitro": "latest",
+    "vite": "latest"
+  },
+  "dependencies": {
+    "@wterm/dom": "workspace:*",
+    "zigpty": "^0.1.6"
+  }
+}

--- a/examples/nitro/terminal.ts
+++ b/examples/nitro/terminal.ts
@@ -1,0 +1,185 @@
+import { defineWebSocketHandler } from "nitro";
+import type { Peer } from "crossws";
+import { spawn, type IPty } from "zigpty";
+
+interface Session {
+  id: string;
+  pty: IPty;
+  cols: number;
+  rows: number;
+  lastCpuUser: number;
+  lastCpuSys: number;
+  lastSampleAt: number;
+  lastStats: StatsPayload | null;
+}
+
+interface StatsPayload {
+  type: "stats";
+  sid: string;
+  pid: number;
+  cwd: string | null;
+  rssBytes: number;
+  cpuPct: number;
+  count: number;
+  proc: string;
+}
+
+const sessions = new Map<string, Session>();
+const peers = new Set<Peer>();
+
+function broadcast(payload: unknown) {
+  const text = JSON.stringify(payload);
+  for (const peer of peers) peer.send(text);
+}
+
+function createSession(id: string, cols: number, rows: number): Session {
+  const pty = spawn(process.env.SHELL || "/bin/bash", [], {
+    cols,
+    rows,
+    cwd: process.env.HOME,
+    env: { ...process.env, TERM: "xterm-256color" },
+  });
+
+  const session: Session = {
+    id,
+    pty,
+    cols,
+    rows,
+    lastCpuUser: 0,
+    lastCpuSys: 0,
+    lastSampleAt: 0,
+    lastStats: null,
+  };
+  sessions.set(id, session);
+  console.log(`[terminal] session opened: ${id} (pid=${pty.pid}, ${cols}x${rows})`);
+
+  pty.onData((data) => {
+    broadcast({ type: "data", sid: id, data });
+  });
+  pty.onExit(({ exitCode }) => {
+    sessions.delete(id);
+    console.log(`[terminal] session exited: ${id} (exitCode=${exitCode})`);
+    broadcast({ type: "closed", sid: id, exitCode });
+  });
+
+  return session;
+}
+
+function sampleStats(session: Session): StatsPayload | null {
+  const s = session.pty.stats();
+  if (!s) return null;
+  const now = Date.now();
+  const elapsedUs = session.lastSampleAt ? (now - session.lastSampleAt) * 1000 : 0;
+  const cpuDelta = s.cpuUser + s.cpuSys - session.lastCpuUser - session.lastCpuSys;
+  const cpuPct = elapsedUs > 0 ? Math.max(0, (cpuDelta / elapsedUs) * 100) : 0;
+  session.lastCpuUser = s.cpuUser;
+  session.lastCpuSys = s.cpuSys;
+  session.lastSampleAt = now;
+
+  const payload: StatsPayload = {
+    type: "stats",
+    sid: session.id,
+    pid: s.pid,
+    cwd: s.cwd,
+    rssBytes: s.rssBytes,
+    cpuPct,
+    count: s.count,
+    proc: session.pty.process,
+  };
+  session.lastStats = payload;
+  return payload;
+}
+
+setInterval(() => {
+  if (peers.size === 0) return;
+  for (const session of sessions.values()) {
+    const payload = sampleStats(session);
+    if (payload) broadcast(payload);
+  }
+}, 1000).unref();
+
+export default defineWebSocketHandler({
+  open(peer) {
+    peers.add(peer);
+    console.log(`[terminal] peer connected (peers=${peers.size})`);
+    const tabs = [...sessions.values()].map((s) => ({
+      id: s.id,
+      stats: sampleStats(s) ?? s.lastStats,
+    }));
+    peer.send(JSON.stringify({ type: "tabs", tabs }));
+    for (const tab of tabs) {
+      if (tab.stats) peer.send(JSON.stringify(tab.stats));
+    }
+  },
+
+  message(peer, message) {
+    const text = message.text();
+    let msg: any;
+    try {
+      msg = JSON.parse(text);
+    } catch {
+      return;
+    }
+    if (!msg || typeof msg !== "object") return;
+
+    const sid: string | undefined = msg.sid;
+
+    switch (msg.type) {
+      case "open": {
+        if (!sid) return;
+        if (sessions.has(sid)) {
+          peer.send(JSON.stringify({ type: "opened", sid }));
+          return;
+        }
+        try {
+          createSession(sid, Number(msg.cols) || 80, Number(msg.rows) || 24);
+          broadcast({ type: "opened", sid });
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          console.error(`[terminal] failed to open session ${sid}: ${errMsg}`);
+          peer.send(
+            JSON.stringify({ type: "error", sid, message: errMsg }),
+          );
+        }
+        return;
+      }
+      case "close": {
+        if (!sid) return;
+        const s = sessions.get(sid);
+        if (s) s.pty.kill();
+        return;
+      }
+      case "input": {
+        if (!sid) return;
+        const s = sessions.get(sid);
+        if (s) s.pty.write(msg.data);
+        return;
+      }
+      case "resize": {
+        if (!sid) return;
+        const s = sessions.get(sid);
+        if (!s) return;
+        s.cols = Number(msg.cols) || s.cols;
+        s.rows = Number(msg.rows) || s.rows;
+        s.pty.resize(s.cols, s.rows);
+        return;
+      }
+      case "rerender": {
+        if (!sid) return;
+        const s = sessions.get(sid);
+        if (s) s.pty.write("\x0c");
+        return;
+      }
+    }
+  },
+
+  close(peer) {
+    peers.delete(peer);
+    console.log(`[terminal] peer disconnected (peers=${peers.size})`);
+  },
+
+  error(peer, error) {
+    peers.delete(peer);
+    console.error(`[terminal] peer error (peers=${peers.size}):`, error);
+  },
+});

--- a/examples/nitro/tsconfig.json
+++ b/examples/nitro/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["nitro/tsconfig"],
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["./*"]
+    }
+  }
+}

--- a/examples/nitro/vite.config.ts
+++ b/examples/nitro/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import { nitro } from "nitro/vite";
+
+export default defineConfig({
+  plugins: [
+    nitro(),
+  ],
+  resolve: {
+    tsconfigPaths: true
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
     devDependencies:
       prettier:
         specifier: ^3.8.2
-        version: 3.8.2
+        version: 3.8.3
       turbo:
         specifier: ^2.9.6
         version: 2.9.6
@@ -24,7 +24,7 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: ^3
-        version: 3.0.161(react@19.2.5)(zod@4.3.6)
+        version: 3.0.163(react@19.2.5)(zod@4.3.6)
       '@mdx-js/loader':
         specifier: ^3
         version: 3.1.1
@@ -57,10 +57,10 @@ importers:
         version: link:../../packages/@wterm/react
       ai:
         specifier: ^6
-        version: 6.0.159(zod@4.3.6)
+        version: 6.0.161(zod@4.3.6)
       bash-tool:
         specifier: ^1
-        version: 1.3.16(ai@6.0.159(zod@4.3.6))(just-bash@2.14.2)
+        version: 1.3.16(ai@6.0.161(zod@4.3.6))(just-bash@2.14.2)
       clsx:
         specifier: ^2
         version: 2.1.1
@@ -266,6 +266,25 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
 
+  examples/nitro:
+    dependencies:
+      '@wterm/dom':
+        specifier: workspace:*
+        version: link:../../packages/@wterm/dom
+      zigpty:
+        specifier: ^0.1.6
+        version: 0.1.6
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      nitro:
+        specifier: latest
+        version: 3.0.260415-beta(@upstash/redis@1.37.0)(dotenv@17.4.2)(jiti@2.6.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite:
+        specifier: latest
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   examples/ssh:
     dependencies:
       '@base-ui/react':
@@ -423,8 +442,8 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@3.0.96':
-    resolution: {integrity: sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==}
+  '@ai-sdk/gateway@3.0.98':
+    resolution: {integrity: sha512-Ol+nP8PIlj8FjN8qKlxhE89N0woqAaGi9CUBGp1boe3RafpphJ7WMuq/RErSvxtwTqje03TP+zIdzP113krxRg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -439,8 +458,8 @@ packages:
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@3.0.161':
-    resolution: {integrity: sha512-lFIZm7OggwNZD08Yz8ip0EPgmEn/lKZOB2MrKjzDpq6BT8gUX17TfaaUi9IICN8nOeLOZQqJKrWNnTXjcvElBw==}
+  '@ai-sdk/react@3.0.163':
+    resolution: {integrity: sha512-UM8BwNx4YFcG1XIBSTepIGx48RXk974qVSplVZc2JPiY86tC4Qpb8trquh5MdtSKzlS6yrUX46n8gS2WZaUIXQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
@@ -1135,6 +1154,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.3':
     resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
 
@@ -1240,6 +1265,9 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1931,6 +1959,98 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2461,8 +2581,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@6.0.159:
-    resolution: {integrity: sha512-S18ozG7Dkm3Ud1tzOtAK5acczD4vygfml80RkpM9VWMFpvAFwAKSHaGYkATvPQHIE+VpD1tJY9zcTXLZ/zR5cw==}
+  ai@6.0.161:
+    resolution: {integrity: sha512-ufhmijmx2YyWTPAicGgtpLOB/xD7mG8zKs1pT1Trj+JL/3r1rS8fkMi/cHZoChSAQSGB4pgmcWVxDrVTUvK2IQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2760,6 +2880,10 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -2809,6 +2933,14 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crossws@0.4.5:
+    resolution: {integrity: sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -2999,6 +3131,29 @@ packages:
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
+  db0@0.3.4:
+    resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
+    peerDependencies:
+      '@electric-sql/pglite': '*'
+      '@libsql/client': '*'
+      better-sqlite3: '*'
+      drizzle-orm: '*'
+      mysql2: '*'
+      sqlite3: '*'
+    peerDependenciesMeta:
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mysql2:
+        optional: true
+      sqlite3:
+        optional: true
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -3139,6 +3294,18 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  env-runner@0.1.7:
+    resolution: {integrity: sha512-i7h96jxETJYhXy5grgHNJ9xNzCzWIn9Ck/VkkYgOlE4gOqknsLX3CmlVb5LmwNex8sOoLFVZLz+TIw/+b5rktA==}
+    hasBin: true
+    peerDependencies:
+      '@netlify/runtime': ^4
+      miniflare: ^4.20260317.3
+    peerDependenciesMeta:
+      '@netlify/runtime':
+        optional: true
+      miniflare:
+        optional: true
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -3381,6 +3548,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -3585,6 +3755,16 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  h3@2.0.1-rc.20:
+    resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
@@ -3658,6 +3838,9 @@ packages:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
 
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -3671,6 +3854,9 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  httpxy@0.5.0:
+    resolution: {integrity: sha512-qwX7QX/rK2visT10/b7bSeZWQOMlSm3svTD0pZpU+vJjNUP0YHtNv4c3z+MO+MSnGuRFWJFdCZiV+7F7dXIOzg==}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -4438,6 +4624,40 @@ packages:
       sass:
         optional: true
 
+  nf3@0.3.16:
+    resolution: {integrity: sha512-Gs0xRPpUm2nDkqbi40NJ9g7qDIcjcJzgExiydnq6LAyqhI2jfno8wG3NKTL+IiJsx799UHOb1CnSd4Wg4SG4Pw==}
+
+  nitro@3.0.260415-beta:
+    resolution: {integrity: sha512-J0ntJERWtIdvweZdmkCiF8eOFvP9fIAJR2gpeIDrHbAlYavK41WQfADo/YoZ/LF7RMTZBiPaH/pt2s/nPru9Iw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@vercel/queue': ^0.1.4
+      dotenv: '*'
+      giget: '*'
+      jiti: ^2.6.1
+      rollup: ^4.60.1
+      vite: ^7 || ^8
+      xml2js: ^0.6.2
+      zephyr-agent: ^0.2.0
+    peerDependenciesMeta:
+      '@vercel/queue':
+        optional: true
+      dotenv:
+        optional: true
+      giget:
+        optional: true
+      jiti:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      xml2js:
+        optional: true
+      zephyr-agent:
+        optional: true
+
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
@@ -4520,6 +4740,15 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  ocache@0.1.4:
+    resolution: {integrity: sha512-e7geNdWjxSnvsSgvLuPvgKgu7ubM10ZmTPOgpr7mz2BXYtvjMKTiLhjFi/gWU8chkuP6hNkZBsa9LzOusyaqkQ==}
+
+  ofetch@2.0.0-alpha.3:
+    resolution: {integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -4685,8 +4914,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.2:
-    resolution: {integrity: sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -4905,6 +5134,14 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rou3@0.8.1:
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -5055,6 +5292,11 @@ packages:
 
   sql.js@1.14.1:
     resolution: {integrity: sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==}
+
+  srvx@0.11.15:
+    resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
 
   ssh2@1.17.0:
     resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
@@ -5370,6 +5612,9 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -5405,6 +5650,80 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  unstorage@2.0.0-alpha.7:
+    resolution: {integrity: sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.11.0
+      '@azure/cosmos': ^4.9.1
+      '@azure/data-tables': ^13.3.2
+      '@azure/identity': ^4.13.0
+      '@azure/keyvault-secrets': ^4.10.0
+      '@azure/storage-blob': ^12.31.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.13.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.36.2
+      '@vercel/blob': '>=0.27.3'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      chokidar: ^4 || ^5
+      db0: '>=0.3.4'
+      idb-keyval: ^6.2.2
+      ioredis: ^5.9.3
+      lru-cache: ^11.2.6
+      mongodb: ^6 || ^7
+      ofetch: '*'
+      uploadthing: ^7.7.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      chokidar:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      lru-cache:
+        optional: true
+      mongodb:
+        optional: true
+      ofetch:
+        optional: true
+      uploadthing:
+        optional: true
 
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
@@ -5466,6 +5785,49 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
@@ -5587,6 +5949,9 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  zigpty@0.1.6:
+    resolution: {integrity: sha512-0B+6Xa4mKgyTNMq87HoGEUb30jQ08DZLEshSlgXPvUv+GB3E0zuTM+IUuYqe0CiaZyaZvCyx9snvGqxIKhl0sA==}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -5609,7 +5974,7 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.96(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.98(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
@@ -5627,10 +5992,10 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.161(react@19.2.5)(zod@4.3.6)':
+  '@ai-sdk/react@3.0.163(react@19.2.5)(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
-      ai: 6.0.159(zod@4.3.6)
+      ai: 6.0.161(zod@4.3.6)
       react: 19.2.5
       swr: 2.4.1(react@19.2.5)
       throttleit: 2.1.0
@@ -6330,6 +6695,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@16.2.3': {}
 
   '@next/eslint-plugin-next@16.2.3':
@@ -6399,6 +6771,8 @@ snapshots:
   '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@oxc-project/types@0.124.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -7147,6 +7521,57 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -7671,9 +8096,9 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.159(zod@4.3.6):
+  ai@6.0.161(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.96(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.98(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
@@ -7813,9 +8238,9 @@ snapshots:
 
   baseline-browser-mapping@2.10.18: {}
 
-  bash-tool@1.3.16(ai@6.0.159(zod@4.3.6))(just-bash@2.14.2):
+  bash-tool@1.3.16(ai@6.0.161(zod@4.3.6))(just-bash@2.14.2):
     dependencies:
-      ai: 6.0.159(zod@4.3.6)
+      ai: 6.0.161(zod@4.3.6)
       fast-glob: 3.3.3
       yaml: 2.8.3
       zod: 3.25.76
@@ -7985,6 +8410,8 @@ snapshots:
 
   confbox@0.1.8: {}
 
+  consola@3.4.2: {}
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
@@ -8030,6 +8457,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crossws@0.4.5(srvx@0.11.15):
+    optionalDependencies:
+      srvx: 0.11.15
 
   cssesc@3.0.0: {}
 
@@ -8245,6 +8676,8 @@ snapshots:
 
   dayjs@1.11.20: {}
 
+  db0@0.3.4: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -8358,6 +8791,13 @@ snapshots:
   entities@6.0.1: {}
 
   env-paths@2.2.1: {}
+
+  env-runner@0.1.7:
+    dependencies:
+      crossws: 0.4.5(srvx@0.11.15)
+      exsolve: 1.0.8
+      httpxy: 0.5.0
+      srvx: 0.11.15
 
   error-ex@1.3.4:
     dependencies:
@@ -8520,7 +8960,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.3
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -8563,7 +9003,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8578,11 +9018,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      get-tsconfig: 4.13.7
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
@@ -8600,7 +9065,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8629,7 +9094,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8878,6 +9343,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  exsolve@1.0.8: {}
+
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -9087,6 +9554,13 @@ snapshots:
 
   graphql@16.13.2: {}
 
+  h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15)):
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.15
+    optionalDependencies:
+      crossws: 0.4.5(srvx@0.11.15)
+
   hachure-fill@0.5.2: {}
 
   has-bigints@1.1.0: {}
@@ -9235,6 +9709,8 @@ snapshots:
 
   hono@4.12.12: {}
 
+  hookable@6.1.1: {}
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
@@ -9253,6 +9729,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  httpxy@0.5.0: {}
 
   human-signals@2.1.0: {}
 
@@ -10246,6 +10724,59 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nf3@0.3.16: {}
+
+  nitro@3.0.260415-beta(@upstash/redis@1.37.0)(dotenv@17.4.2)(jiti@2.6.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.5(srvx@0.11.15)
+      db0: 0.3.4
+      env-runner: 0.1.7
+      h3: 2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15))
+      hookable: 6.1.1
+      nf3: 0.3.16
+      ocache: 0.1.4
+      ofetch: 2.0.0-alpha.3
+      ohash: 2.0.11
+      rolldown: 1.0.0-rc.15
+      srvx: 0.11.15
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.7(@upstash/redis@1.37.0)(db0@0.3.4)(ofetch@2.0.0-alpha.3)
+    optionalDependencies:
+      dotenv: 17.4.2
+      jiti: 2.6.1
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - sqlite3
+      - uploadthing
+
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
@@ -10338,6 +10869,14 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  ocache@0.1.4:
+    dependencies:
+      ohash: 2.0.11
+
+  ofetch@2.0.0-alpha.3: {}
+
+  ohash@2.0.11: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -10522,7 +11061,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.2: {}
+  prettier@3.8.3: {}
 
   pretty-ms@9.3.0:
     dependencies:
@@ -10860,6 +11399,29 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
+  rolldown@1.0.0-rc.15:
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+
+  rou3@0.8.1: {}
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -11117,6 +11679,8 @@ snapshots:
   sprintf-js@1.1.3: {}
 
   sql.js@1.14.1: {}
+
+  srvx@0.11.15: {}
 
   ssh2@1.17.0:
     dependencies:
@@ -11492,6 +12056,10 @@ snapshots:
 
   undici-types@7.19.2: {}
 
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
   unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
@@ -11559,6 +12127,12 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  unstorage@2.0.0-alpha.7(@upstash/redis@1.37.0)(db0@0.3.4)(ofetch@2.0.0-alpha.3):
+    optionalDependencies:
+      '@upstash/redis': 1.37.0
+      db0: 0.3.4
+      ofetch: 2.0.0-alpha.3
+
   until-async@3.0.2: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
@@ -11612,6 +12186,21 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      yaml: 2.8.3
 
   vscode-jsonrpc@8.2.0: {}
 
@@ -11733,6 +12322,8 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zigpty@0.1.6: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
Adds a new `examples/nitro` example and links it from the root README and docs navigation.

- Full terminal running on real PTYs (via [zigpty](https://github.com/pithings/zigpty)) allocated by a [Nitro](https://nitro.build) backend.
- Each in-app tab is a named session; the server keeps a shared PTY per session id.
- Cross-window sync: new windows attach to all live sessions; `opened` / `closed` broadcasts keep every browser's tab bar in sync.
- Per-session stats (pid, cwd, cpu%, rss, proc count, foreground proc) sampled every second and broadcast.
- Theme switcher (Default, Solarized Dark, Monokai, Light).

<img width="1838" height="1767" alt="Screenshot_20260415_112901" src="https://github.com/user-attachments/assets/0355cbff-ea66-430e-b7c4-9d3ec00600ea" />

(generated with claude code i haven't verified all impl details)