### PR TITLE
prepare v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Changelog
 
-## 0.1.6
+## 0.1.7
 
 <!-- release:start -->
+
+### Improvements
+
+- **Zero-boilerplate usage** — `<Terminal />` and `new WTerm(el)` now work out of the box with no `onData` wiring required. When `onData` is omitted, typed input is echoed back automatically (#16)
+- **Simpler getting-started examples** — docs, READMEs, and configuration pages updated to show the minimal one-liner usage first, with `onData` / `useTerminal` documented as an advanced pattern (#16, #17)
+- **Faster docs layout** — removed server-side cookie reads from the root layout, making it synchronous; chat panel state is now fully client-driven via `useSyncExternalStore`
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.1.6
 
 ### Bug Fixes
 
@@ -16,8 +30,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.1.5
 

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -8,7 +8,6 @@ import { DocsChat } from "@/components/docs-chat";
 import { DocsMobileNav } from "@/components/docs-mobile-nav";
 import { DocsNav } from "@/components/docs-nav";
 import { getStarCount } from "@/lib/github";
-import { cookies } from "next/headers";
 import "./globals.css";
 
 export const viewport: Viewport = {
@@ -121,35 +120,20 @@ async function Header() {
   );
 }
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const cookieStore = await cookies();
-  const chatOpen = cookieStore.get("docs-chat-open")?.value === "true";
-  const chatWidth = Math.min(
-    700,
-    Math.max(300, Number(cookieStore.get("docs-chat-width")?.value) || 400),
-  );
-
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>
-        {chatOpen && (
-          <style
-            dangerouslySetInnerHTML={{
-              __html: `@media(min-width:640px){body{padding-right:${chatWidth}px}}`,
-            }}
-          />
-        )}
-      </head>
+      <head />
       <body className="bg-white text-neutral-900 antialiased dark:bg-neutral-950 dark:text-neutral-100">
         <ThemeProvider>
           <Header />
           <DocsMobileNav />
           <DocsNav>{children}</DocsNav>
-          <DocsChat defaultOpen={chatOpen} defaultWidth={chatWidth} />
+          <DocsChat />
         </ThemeProvider>
       </body>
     </html>

--- a/apps/docs/src/components/docs-chat.tsx
+++ b/apps/docs/src/components/docs-chat.tsx
@@ -466,10 +466,7 @@ function useCookieState(
     getSnapshot,
     getServerSnapshot,
   );
-  const setValue = useCallback(
-    (v: string) => writeCookie(name, v),
-    [name],
-  );
+  const setValue = useCallback((v: string) => writeCookie(name, v), [name]);
   return [value, setValue];
 }
 

--- a/apps/docs/src/components/docs-chat.tsx
+++ b/apps/docs/src/components/docs-chat.tsx
@@ -19,17 +19,25 @@ const DESKTOP_DEFAULT_WIDTH = 400;
 const DESKTOP_MIN_WIDTH = 300;
 const DESKTOP_MAX_WIDTH = 700;
 
-function setCookie(name: string, value: string) {
+const COOKIE_CHANGE = "docs-chat-cookie";
+
+function writeCookie(name: string, value: string) {
   document.cookie = `${name}=${encodeURIComponent(value)};path=/;max-age=${60 * 60 * 24 * 365};samesite=lax`;
+  window.dispatchEvent(new Event(COOKIE_CHANGE));
 }
 
-function getCookie(name: string): string | undefined {
+function readCookie(name: string): string | undefined {
   const match = document.cookie.match(
     new RegExp(
       "(?:^|; )" + name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "=([^;]*)",
     ),
   );
   return match ? decodeURIComponent(match[1]) : undefined;
+}
+
+function subscribeCookies(cb: () => void) {
+  window.addEventListener(COOKIE_CHANGE, cb);
+  return () => window.removeEventListener(COOKIE_CHANGE, cb);
 }
 
 const subscribeNoop = () => () => {};
@@ -444,46 +452,61 @@ function ChatTerminal() {
 // DocsChat — panel wrapper (aside on desktop, Sheet on mobile)
 // ---------------------------------------------------------------------------
 
+function useCookieState(
+  name: string,
+  serverDefault: string,
+): [string, (v: string) => void] {
+  const getSnapshot = useCallback(
+    () => readCookie(name) ?? serverDefault,
+    [name, serverDefault],
+  );
+  const getServerSnapshot = useCallback(() => serverDefault, [serverDefault]);
+  const value = useSyncExternalStore(
+    subscribeCookies,
+    getSnapshot,
+    getServerSnapshot,
+  );
+  const setValue = useCallback(
+    (v: string) => writeCookie(name, v),
+    [name],
+  );
+  return [value, setValue];
+}
+
 export function DocsChat() {
   const isDesktop = useMediaQuery("(min-width: 640px)");
   const hasMounted = useMounted();
 
-  const [open, setOpen] = useState(false);
-  const [desktopWidth, setDesktopWidth] = useState(DESKTOP_DEFAULT_WIDTH);
-  const isDraggingRef = useRef(false);
-  const [hasBeenOpened, setHasBeenOpened] = useState(false);
+  const [openStr, setOpenStr] = useCookieState("docs-chat-open", "false");
+  const [widthStr, setWidthStr] = useCookieState(
+    "docs-chat-width",
+    String(DESKTOP_DEFAULT_WIDTH),
+  );
 
-  // Cookie restore must run after hydration to avoid server/client mismatch
-  useEffect(() => {
-    const storedOpen = getCookie("docs-chat-open") === "true";
-    const storedWidth = Number(getCookie("docs-chat-width"));
-    if (storedOpen) {
-      setOpen(true);
-      setHasBeenOpened(true);
-    }
-    if (storedWidth) {
-      setDesktopWidth(
-        Math.min(DESKTOP_MAX_WIDTH, Math.max(DESKTOP_MIN_WIDTH, storedWidth)),
-      );
-    }
-  }, []);
+  const open = openStr === "true";
+  const desktopWidth = Math.min(
+    DESKTOP_MAX_WIDTH,
+    Math.max(DESKTOP_MIN_WIDTH, Number(widthStr) || DESKTOP_DEFAULT_WIDTH),
+  );
+
+  const [hasBeenOpened, setHasBeenOpened] = useState(false);
+  const showTerminal = open || hasBeenOpened;
+  const isDraggingRef = useRef(false);
 
   const updateOpen = useCallback(
     (next: boolean | ((prev: boolean) => boolean)) => {
-      setOpen((prev) => {
-        const val = typeof next === "function" ? next(prev) : next;
-        setCookie("docs-chat-open", String(val));
-        if (val) setHasBeenOpened(true);
-        return val;
-      });
+      const current = readCookie("docs-chat-open") === "true";
+      const val = typeof next === "function" ? next(current) : next;
+      setOpenStr(String(val));
+      if (val) setHasBeenOpened(true);
     },
-    [],
+    [setOpenStr],
   );
 
-  const updateDesktopWidth = useCallback((next: number) => {
-    setDesktopWidth(next);
-    setCookie("docs-chat-width", String(next));
-  }, []);
+  const updateDesktopWidth = useCallback(
+    (next: number) => setWidthStr(String(next)),
+    [setWidthStr],
+  );
 
   // Keyboard: Cmd/Ctrl+I toggles panel, Escape closes desktop panel
   useEffect(() => {
@@ -598,7 +621,7 @@ export function DocsChat() {
           className="absolute top-0 bottom-0 left-0 w-1.5 cursor-col-resize hover:bg-neutral-300/30 dark:hover:bg-neutral-600/30 active:bg-neutral-300/50 dark:active:bg-neutral-600/50 transition-colors z-10"
         />
         <div className="flex flex-col flex-1 min-w-0">
-          {hasBeenOpened && chatPanel}
+          {showTerminal && chatPanel}
         </div>
       </aside>
 

--- a/apps/docs/src/components/docs-chat.tsx
+++ b/apps/docs/src/components/docs-chat.tsx
@@ -25,7 +25,9 @@ function setCookie(name: string, value: string) {
 
 function getCookie(name: string): string | undefined {
   const match = document.cookie.match(
-    new RegExp("(?:^|; )" + name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "=([^;]*)"),
+    new RegExp(
+      "(?:^|; )" + name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "=([^;]*)",
+    ),
   );
   return match ? decodeURIComponent(match[1]) : undefined;
 }

--- a/apps/docs/src/components/docs-chat.tsx
+++ b/apps/docs/src/components/docs-chat.tsx
@@ -23,6 +23,13 @@ function setCookie(name: string, value: string) {
   document.cookie = `${name}=${encodeURIComponent(value)};path=/;max-age=${60 * 60 * 24 * 365};samesite=lax`;
 }
 
+function getCookie(name: string): string | undefined {
+  const match = document.cookie.match(
+    new RegExp("(?:^|; )" + name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "=([^;]*)"),
+  );
+  return match ? decodeURIComponent(match[1]) : undefined;
+}
+
 const subscribeNoop = () => () => {};
 const returnTrue = () => true;
 const returnFalse = () => false;
@@ -435,22 +442,29 @@ function ChatTerminal() {
 // DocsChat — panel wrapper (aside on desktop, Sheet on mobile)
 // ---------------------------------------------------------------------------
 
-export function DocsChat({
-  defaultOpen = false,
-  defaultWidth = DESKTOP_DEFAULT_WIDTH,
-}: {
-  defaultOpen?: boolean;
-  defaultWidth?: number;
-}) {
+export function DocsChat() {
   const isDesktop = useMediaQuery("(min-width: 640px)");
   const hasMounted = useMounted();
 
-  const [open, setOpen] = useState(defaultOpen);
-  const [desktopWidth, setDesktopWidth] = useState(
-    Math.min(DESKTOP_MAX_WIDTH, Math.max(DESKTOP_MIN_WIDTH, defaultWidth)),
-  );
+  const [open, setOpen] = useState(false);
+  const [desktopWidth, setDesktopWidth] = useState(DESKTOP_DEFAULT_WIDTH);
   const isDraggingRef = useRef(false);
-  const [hasBeenOpened, setHasBeenOpened] = useState(defaultOpen);
+  const [hasBeenOpened, setHasBeenOpened] = useState(false);
+
+  // Cookie restore must run after hydration to avoid server/client mismatch
+  useEffect(() => {
+    const storedOpen = getCookie("docs-chat-open") === "true";
+    const storedWidth = Number(getCookie("docs-chat-width"));
+    if (storedOpen) {
+      setOpen(true);
+      setHasBeenOpened(true);
+    }
+    if (storedWidth) {
+      setDesktopWidth(
+        Math.min(DESKTOP_MAX_WIDTH, Math.max(DESKTOP_MIN_WIDTH, storedWidth)),
+      );
+    }
+  }, []);
 
   const updateOpen = useCallback(
     (next: boolean | ((prev: boolean) => boolean)) => {

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Headless terminal emulator core for the web — WASM bridge and WebSocket transport",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/dom",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "DOM renderer, input handler, and orchestrator for wterm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/just-bash",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "just-bash shell adapter for wterm — line editing, tab completion, history, prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/markdown",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Streaming markdown-to-ANSI renderer for wterm terminals",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/react",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "React component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bump all `@wterm/*` packages to **0.1.7**
- Add changelog entry for zero-boilerplate usage, simpler getting-started examples, and faster docs layout

## Changelog

### Improvements

- **Zero-boilerplate usage** — `<Terminal />` and `new WTerm(el)` now work out of the box with no `onData` wiring required. When `onData` is omitted, typed input is echoed back automatically (#16)
- **Simpler getting-started examples** — docs, READMEs, and configuration pages updated to show the minimal one-liner usage first, with `onData` / `useTerminal` documented as an advanced pattern (#16, #17)
- **Faster docs layout** — removed server-side cookie reads from the root layout, making it synchronous; chat panel state is now fully client-driven via `useSyncExternalStore`