### PR TITLE
Add Vitest testing across all @wterm/* packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Test
+        run: pnpm test
+
       - name: Lint
         run: pnpm lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 .next/
 next-env.d.ts
 packages/@wterm/core/src/wasm-inline.ts
+coverage/

--- a/package.json
+++ b/package.json
@@ -16,11 +16,14 @@
     "lint": "turbo run lint",
     "publish-packages": "pnpm build && pnpm --filter './packages/@wterm/*' publish --no-git-checks",
     "sync-versions": "node scripts/sync-versions.mjs",
+    "test": "turbo run test",
     "type-check": "turbo run type-check"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.4",
     "prettier": "^3.8.2",
-    "turbo": "^2.9.6"
+    "turbo": "^2.9.6",
+    "vitest": "^4.1.4"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -21,6 +21,7 @@
     "prebuild": "node scripts/inline-wasm.js",
     "build": "tsc",
     "prepublishOnly": "pnpm build",
+    "test": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/@wterm/core/src/__tests__/wasm-bridge.test.ts
+++ b/packages/@wterm/core/src/__tests__/wasm-bridge.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { WasmBridge } from "../wasm-bridge.js";
+
+describe("WasmBridge", () => {
+  let bridge: WasmBridge;
+
+  beforeEach(async () => {
+    bridge = await WasmBridge.load();
+    bridge.init(80, 24);
+  });
+
+  describe("load", () => {
+    it("loads from inline base64", async () => {
+      const b = await WasmBridge.load();
+      expect(b).toBeInstanceOf(WasmBridge);
+    });
+
+    it("throws on invalid URL fetch", async () => {
+      await expect(
+        WasmBridge.load("http://localhost:99999/nonexistent.wasm"),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("init", () => {
+    it("sets cols and rows", () => {
+      expect(bridge.getCols()).toBe(80);
+      expect(bridge.getRows()).toBe(24);
+    });
+  });
+
+  describe("writeString / getCell", () => {
+    it("writes a character to the grid", () => {
+      bridge.writeString("A");
+      const cell = bridge.getCell(0, 0);
+      expect(cell.char).toBe(65); // 'A'
+    });
+
+    it("writes multiple characters sequentially", () => {
+      bridge.writeString("Hi");
+      expect(bridge.getCell(0, 0).char).toBe(72); // 'H'
+      expect(bridge.getCell(0, 1).char).toBe(105); // 'i'
+    });
+
+    it("writes to correct position after cursor movement", () => {
+      bridge.writeString("AB\r\nCD");
+      expect(bridge.getCell(0, 0).char).toBe(65); // 'A'
+      expect(bridge.getCell(0, 1).char).toBe(66); // 'B'
+      expect(bridge.getCell(1, 0).char).toBe(67); // 'C'
+      expect(bridge.getCell(1, 1).char).toBe(68); // 'D'
+    });
+  });
+
+  describe("writeRaw", () => {
+    it("writes raw bytes to the terminal", () => {
+      const data = new TextEncoder().encode("X");
+      bridge.writeRaw(data);
+      expect(bridge.getCell(0, 0).char).toBe(88); // 'X'
+    });
+  });
+
+  describe("cursor", () => {
+    it("returns initial cursor at 0,0", () => {
+      const cursor = bridge.getCursor();
+      expect(cursor.row).toBe(0);
+      expect(cursor.col).toBe(0);
+      expect(cursor.visible).toBe(true);
+    });
+
+    it("advances cursor after writing", () => {
+      bridge.writeString("Hello");
+      const cursor = bridge.getCursor();
+      expect(cursor.col).toBe(5);
+      expect(cursor.row).toBe(0);
+    });
+
+    it("moves to next row after newline", () => {
+      bridge.writeString("A\r\nB");
+      const cursor = bridge.getCursor();
+      expect(cursor.row).toBe(1);
+      expect(cursor.col).toBe(1);
+    });
+  });
+
+  describe("dirty rows", () => {
+    it("marks rows dirty after writing", () => {
+      bridge.writeString("text");
+      expect(bridge.isDirtyRow(0)).toBe(true);
+    });
+
+    it("clears dirty flags", () => {
+      bridge.writeString("text");
+      bridge.clearDirty();
+      expect(bridge.isDirtyRow(0)).toBe(false);
+    });
+  });
+
+  describe("resize", () => {
+    it("changes cols and rows", () => {
+      bridge.resize(40, 12);
+      expect(bridge.getCols()).toBe(40);
+      expect(bridge.getRows()).toBe(12);
+    });
+
+    it("preserves content after resize", () => {
+      bridge.writeString("A");
+      bridge.resize(40, 12);
+      expect(bridge.getCell(0, 0).char).toBe(65);
+    });
+  });
+
+  describe("SGR attributes", () => {
+    it("tracks foreground color", () => {
+      bridge.writeString("\x1b[31mR");
+      const cell = bridge.getCell(0, 0);
+      expect(cell.char).toBe(82); // 'R'
+      expect(cell.fg).not.toBe(256); // not default
+    });
+
+    it("tracks bold flag", () => {
+      bridge.writeString("\x1b[1mB");
+      const cell = bridge.getCell(0, 0);
+      expect(cell.flags & 0x01).toBe(0x01);
+    });
+  });
+
+  describe("mode flags", () => {
+    it("defaults cursorKeysApp to false", () => {
+      expect(bridge.cursorKeysApp()).toBe(false);
+    });
+
+    it("enables cursor keys application mode", () => {
+      bridge.writeString("\x1b[?1h");
+      expect(bridge.cursorKeysApp()).toBe(true);
+    });
+
+    it("defaults bracketedPaste to false", () => {
+      expect(bridge.bracketedPaste()).toBe(false);
+    });
+
+    it("enables bracketed paste mode", () => {
+      bridge.writeString("\x1b[?2004h");
+      expect(bridge.bracketedPaste()).toBe(true);
+    });
+
+    it("defaults usingAltScreen to false", () => {
+      expect(bridge.usingAltScreen()).toBe(false);
+    });
+
+    it("enters alt screen buffer", () => {
+      bridge.writeString("\x1b[?1049h");
+      expect(bridge.usingAltScreen()).toBe(true);
+    });
+
+    it("exits alt screen buffer", () => {
+      bridge.writeString("\x1b[?1049h");
+      bridge.writeString("\x1b[?1049l");
+      expect(bridge.usingAltScreen()).toBe(false);
+    });
+  });
+
+  describe("title", () => {
+    it("returns null when no title set", () => {
+      expect(bridge.getTitle()).toBeNull();
+    });
+
+    it("captures OSC title sequence", () => {
+      bridge.writeString("\x1b]0;My Title\x07");
+      const title = bridge.getTitle();
+      expect(title).toBe("My Title");
+    });
+  });
+
+  describe("scrollback", () => {
+    it("starts with zero scrollback", () => {
+      expect(bridge.getScrollbackCount()).toBe(0);
+    });
+
+    it("accumulates scrollback when content overflows", () => {
+      for (let i = 0; i < 30; i++) {
+        bridge.writeString(`line ${i}\r\n`);
+      }
+      expect(bridge.getScrollbackCount()).toBeGreaterThan(0);
+    });
+
+    it("reads scrollback cell data", () => {
+      for (let i = 0; i < 30; i++) {
+        bridge.writeString(`A\r\n`);
+      }
+      const count = bridge.getScrollbackCount();
+      if (count > 0) {
+        const cell = bridge.getScrollbackCell(0, 0);
+        expect(cell.char).toBe(65); // 'A'
+      }
+    });
+
+    it("returns scrollback line length", () => {
+      for (let i = 0; i < 30; i++) {
+        bridge.writeString(`AB\r\n`);
+      }
+      const count = bridge.getScrollbackCount();
+      if (count > 0) {
+        const len = bridge.getScrollbackLineLen(0);
+        expect(len).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/packages/@wterm/core/src/__tests__/websocket-transport.test.ts
+++ b/packages/@wterm/core/src/__tests__/websocket-transport.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { WebSocketTransport } from "../transport.js";
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  readyState = MockWebSocket.CONNECTING;
+  binaryType = "blob";
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  sent: (string | ArrayBufferView)[] = [];
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  send(data: string | ArrayBufferView) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.closed = true;
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  simulateMessage(data: string | ArrayBuffer) {
+    this.onmessage?.(new MessageEvent("message", { data }));
+  }
+
+  simulateError() {
+    this.onerror?.(new Event("error"));
+  }
+}
+
+let mockInstances: MockWebSocket[] = [];
+
+function installMockWebSocket() {
+  mockInstances = [];
+  vi.stubGlobal(
+    "WebSocket",
+    Object.assign(
+      class extends MockWebSocket {
+        constructor(url: string) {
+          super(url);
+          mockInstances.push(this);
+        }
+      },
+      {
+        CONNECTING: 0,
+        OPEN: 1,
+        CLOSING: 2,
+        CLOSED: 3,
+      },
+    ),
+  );
+}
+
+describe("WebSocketTransport", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    installMockWebSocket();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  describe("constructor", () => {
+    it("sets defaults", () => {
+      const t = new WebSocketTransport();
+      expect(t.url).toBeNull();
+      expect(t.reconnect).toBe(true);
+      expect(t.maxReconnectDelay).toBe(30000);
+    });
+
+    it("accepts options", () => {
+      const t = new WebSocketTransport({
+        url: "ws://localhost:3000",
+        reconnect: false,
+        maxReconnectDelay: 5000,
+      });
+      expect(t.url).toBe("ws://localhost:3000");
+      expect(t.reconnect).toBe(false);
+      expect(t.maxReconnectDelay).toBe(5000);
+    });
+  });
+
+  describe("connect", () => {
+    it("creates a WebSocket connection", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      expect(mockInstances).toHaveLength(1);
+      expect(mockInstances[0].url).toBe("ws://test");
+    });
+
+    it("accepts URL parameter", () => {
+      const t = new WebSocketTransport();
+      t.connect("ws://override");
+      expect(t.url).toBe("ws://override");
+      expect(mockInstances[0].url).toBe("ws://override");
+    });
+
+    it("throws without URL", () => {
+      const t = new WebSocketTransport();
+      expect(() => t.connect()).toThrow("No WebSocket URL provided");
+    });
+
+    it("sets binaryType to arraybuffer", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      expect(mockInstances[0].binaryType).toBe("arraybuffer");
+    });
+  });
+
+  describe("callbacks", () => {
+    it("calls onOpen when connection opens", () => {
+      const onOpen = vi.fn();
+      const t = new WebSocketTransport({ url: "ws://test", onOpen });
+      t.connect();
+      mockInstances[0].simulateOpen();
+      expect(onOpen).toHaveBeenCalledOnce();
+    });
+
+    it("calls onData for string messages", () => {
+      const onData = vi.fn();
+      const t = new WebSocketTransport({ url: "ws://test", onData });
+      t.connect();
+      mockInstances[0].simulateOpen();
+      mockInstances[0].simulateMessage("hello");
+      expect(onData).toHaveBeenCalledWith("hello");
+    });
+
+    it("calls onData with Uint8Array for binary messages", () => {
+      const onData = vi.fn();
+      const t = new WebSocketTransport({ url: "ws://test", onData });
+      t.connect();
+      mockInstances[0].simulateOpen();
+      const buf = new ArrayBuffer(3);
+      mockInstances[0].simulateMessage(buf);
+      expect(onData).toHaveBeenCalledWith(expect.any(Uint8Array));
+    });
+
+    it("calls onClose when connection closes", () => {
+      const onClose = vi.fn();
+      const t = new WebSocketTransport({
+        url: "ws://test",
+        onClose,
+        reconnect: false,
+      });
+      t.connect();
+      mockInstances[0].simulateOpen();
+      mockInstances[0].close();
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("calls onError on error", () => {
+      const onError = vi.fn();
+      const t = new WebSocketTransport({
+        url: "ws://test",
+        onError,
+        reconnect: false,
+      });
+      t.connect();
+      mockInstances[0].simulateError();
+      expect(onError).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("send", () => {
+    it("sends data through open connection", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      mockInstances[0].simulateOpen();
+      t.send("test data");
+      expect(mockInstances[0].sent).toHaveLength(1);
+    });
+
+    it("buffers data when not connected", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      t.send("buffered");
+      expect(mockInstances[0].sent).toHaveLength(0);
+    });
+
+    it("flushes buffer on open", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      t.send("msg1");
+      t.send("msg2");
+      mockInstances[0].simulateOpen();
+      expect(mockInstances[0].sent).toHaveLength(2);
+    });
+  });
+
+  describe("close", () => {
+    it("closes the connection", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      t.close();
+      expect(mockInstances[0].closed).toBe(true);
+    });
+
+    it("prevents reconnection", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      t.close();
+      vi.advanceTimersByTime(60000);
+      expect(mockInstances).toHaveLength(1);
+    });
+  });
+
+  describe("connected", () => {
+    it("returns false before connect", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      expect(t.connected).toBe(false);
+    });
+
+    it("returns true when open", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      mockInstances[0].simulateOpen();
+      expect(t.connected).toBe(true);
+    });
+
+    it("returns false after close", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      mockInstances[0].simulateOpen();
+      t.close();
+      expect(t.connected).toBe(false);
+    });
+  });
+
+  describe("reconnect", () => {
+    it("reconnects after unexpected close", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      mockInstances[0].simulateOpen();
+      mockInstances[0].close();
+
+      vi.advanceTimersByTime(1000);
+      expect(mockInstances).toHaveLength(2);
+    });
+
+    it("doubles delay on subsequent reconnects", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      mockInstances[0].close();
+
+      vi.advanceTimersByTime(1000);
+      expect(mockInstances).toHaveLength(2);
+
+      mockInstances[1].close();
+      vi.advanceTimersByTime(1999);
+      expect(mockInstances).toHaveLength(2);
+      vi.advanceTimersByTime(1);
+      expect(mockInstances).toHaveLength(3);
+    });
+
+    it("caps reconnect delay at maxReconnectDelay", () => {
+      const t = new WebSocketTransport({
+        url: "ws://test",
+        maxReconnectDelay: 4000,
+      });
+      t.connect();
+
+      for (let i = 0; i < 10; i++) {
+        mockInstances[mockInstances.length - 1].close();
+        vi.advanceTimersByTime(4000);
+      }
+      expect(mockInstances.length).toBeGreaterThan(5);
+    });
+
+    it("resets delay after successful open", () => {
+      const t = new WebSocketTransport({ url: "ws://test" });
+      t.connect();
+      mockInstances[0].close();
+      vi.advanceTimersByTime(1000);
+      mockInstances[1].simulateOpen();
+      mockInstances[1].close();
+
+      vi.advanceTimersByTime(1000);
+      expect(mockInstances).toHaveLength(3);
+    });
+
+    it("does not reconnect when reconnect is false", () => {
+      const t = new WebSocketTransport({
+        url: "ws://test",
+        reconnect: false,
+      });
+      t.connect();
+      mockInstances[0].close();
+
+      vi.advanceTimersByTime(60000);
+      expect(mockInstances).toHaveLength(1);
+    });
+  });
+});

--- a/packages/@wterm/core/vitest.config.ts
+++ b/packages/@wterm/core/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/wasm-inline.ts",
+      ],
+    },
+  },
+});

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "pnpm build",
+    "test": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@internal/ts": "workspace:*",
+    "jsdom": "^29.0.2",
     "typescript": "^6.0.2"
   },
   "keywords": [

--- a/packages/@wterm/dom/src/__tests__/input.test.ts
+++ b/packages/@wterm/dom/src/__tests__/input.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { InputHandler } from "../input.js";
+import type { WasmBridge } from "@wterm/core";
+
+function createKeyboardEvent(
+  key: string,
+  opts: Partial<KeyboardEventInit> = {},
+): KeyboardEvent {
+  return new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...opts,
+  });
+}
+
+describe("InputHandler", () => {
+  let container: HTMLElement;
+  let received: string[];
+  let handler: InputHandler;
+  let bridgeMock: WasmBridge | null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    received = [];
+    bridgeMock = null;
+
+    handler = new InputHandler(
+      container,
+      (data) => received.push(data),
+      () => bridgeMock,
+    );
+  });
+
+  afterEach(() => {
+    handler.destroy();
+    container.remove();
+  });
+
+  function getTextarea(): HTMLTextAreaElement {
+    return container.querySelector("textarea")!;
+  }
+
+  describe("setup", () => {
+    it("creates a hidden textarea in the container", () => {
+      const ta = getTextarea();
+      expect(ta).not.toBeNull();
+      expect(ta.getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("sets autocomplete off attributes", () => {
+      const ta = getTextarea();
+      expect(ta.getAttribute("autocomplete")).toBe("off");
+      expect(ta.getAttribute("spellcheck")).toBe("false");
+    });
+  });
+
+  describe("focus", () => {
+    it("focuses the textarea", () => {
+      const ta = getTextarea();
+      const focusSpy = vi.spyOn(ta, "focus");
+      handler.focus();
+      expect(focusSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("key mapping - fixed keys", () => {
+    it("maps Enter to carriage return", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("Enter"));
+      expect(received).toContain("\r");
+    });
+
+    it("maps Backspace to DEL", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("Backspace"));
+      expect(received).toContain("\x7f");
+    });
+
+    it("maps Tab to tab character", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("Tab"));
+      expect(received).toContain("\t");
+    });
+
+    it("maps Escape key", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("Escape"));
+      expect(received).toContain("\x1b");
+    });
+  });
+
+  describe("key mapping - arrow keys (normal mode)", () => {
+    it("maps ArrowUp", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("ArrowUp"));
+      expect(received).toContain("\x1b[A");
+    });
+
+    it("maps ArrowDown", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("ArrowDown"));
+      expect(received).toContain("\x1b[B");
+    });
+
+    it("maps ArrowRight", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("ArrowRight"));
+      expect(received).toContain("\x1b[C");
+    });
+
+    it("maps ArrowLeft", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("ArrowLeft"));
+      expect(received).toContain("\x1b[D");
+    });
+  });
+
+  describe("key mapping - arrow keys (application mode)", () => {
+    beforeEach(() => {
+      bridgeMock = { cursorKeysApp: () => true } as any;
+    });
+
+    it("maps ArrowUp to application mode", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("ArrowUp"));
+      expect(received).toContain("\x1bOA");
+    });
+
+    it("maps ArrowDown to application mode", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("ArrowDown"));
+      expect(received).toContain("\x1bOB");
+    });
+  });
+
+  describe("key mapping - ctrl sequences", () => {
+    it("maps Ctrl+A to SOH", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("a", { ctrlKey: true }));
+      expect(received).toContain("\x01");
+    });
+
+    it("maps Ctrl+C to ETX", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("c", { ctrlKey: true }));
+      expect(received).toContain("\x03");
+    });
+
+    it("maps Ctrl+Z to SUB", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("z", { ctrlKey: true }));
+      expect(received).toContain("\x1a");
+    });
+  });
+
+  describe("key mapping - alt modifier", () => {
+    it("prepends ESC for Alt+letter", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("b", { altKey: true }));
+      expect(received).toContain("\x1bb");
+    });
+
+    it("prepends ESC for Alt+Enter", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("Enter", { altKey: true }));
+      expect(received).toContain("\x1b\r");
+    });
+  });
+
+  describe("key mapping - shift combinations", () => {
+    it("maps Shift+Enter to CSI 13;2u", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("Enter", { shiftKey: true }));
+      expect(received).toContain("\x1b[13;2u");
+    });
+
+    it("maps Shift+Tab to reverse tab", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("Tab", { shiftKey: true }));
+      expect(received).toContain("\x1b[Z");
+    });
+  });
+
+  describe("printable characters", () => {
+    it("sends single printable characters", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("x"));
+      expect(received).toContain("x");
+    });
+  });
+
+  describe("paste", () => {
+    it("sends pasted text as-is without bracketed paste", () => {
+      const ta = getTextarea();
+      const pasteEvent = new Event("paste", {
+        bubbles: true,
+        cancelable: true,
+      }) as any;
+      pasteEvent.clipboardData = { getData: () => "pasted text" };
+      ta.dispatchEvent(pasteEvent);
+      expect(received).toContain("pasted text");
+    });
+
+    it("wraps pasted text in bracketed paste sequences", () => {
+      bridgeMock = { bracketedPaste: () => true } as any;
+      const ta = getTextarea();
+      const pasteEvent = new Event("paste", {
+        bubbles: true,
+        cancelable: true,
+      }) as any;
+      pasteEvent.clipboardData = { getData: () => "hello" };
+      ta.dispatchEvent(pasteEvent);
+      expect(received).toContain("\x1b[200~hello\x1b[201~");
+    });
+  });
+
+  describe("destroy", () => {
+    it("removes textarea from DOM", () => {
+      handler.destroy();
+      expect(container.querySelector("textarea")).toBeNull();
+    });
+
+    it("removes focused class", () => {
+      container.classList.add("focused");
+      handler.destroy();
+      expect(container.classList.contains("focused")).toBe(false);
+    });
+
+    it("stops responding to key events", () => {
+      handler.destroy();
+      const ta = document.createElement("textarea");
+      container.appendChild(ta);
+      ta.dispatchEvent(createKeyboardEvent("a"));
+      expect(received).toHaveLength(0);
+    });
+  });
+});

--- a/packages/@wterm/dom/src/__tests__/renderer.test.ts
+++ b/packages/@wterm/dom/src/__tests__/renderer.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Renderer } from "../renderer.js";
+import type { CellData, CursorState } from "@wterm/core";
+
+function createMockBridge(cols: number, rows: number, grid: CellData[][] = []) {
+  const dirtyRows = new Set<number>();
+  for (let r = 0; r < rows; r++) dirtyRows.add(r);
+
+  return {
+    getCols: () => cols,
+    getRows: () => rows,
+    getCell: (row: number, col: number): CellData =>
+      grid[row]?.[col] ?? { char: 0, fg: 256, bg: 256, flags: 0 },
+    isDirtyRow: (row: number) => dirtyRows.has(row),
+    clearDirty: () => dirtyRows.clear(),
+    getCursor: (): CursorState => ({ row: 0, col: 0, visible: true }),
+    getScrollbackCount: () => 0,
+    getScrollbackCell: (_offset: number, _col: number): CellData => ({
+      char: 0,
+      fg: 256,
+      bg: 256,
+      flags: 0,
+    }),
+    getScrollbackLineLen: () => 0,
+  };
+}
+
+function makeCell(char: string, fg = 256, bg = 256, flags = 0): CellData {
+  return { char: char.codePointAt(0)!, fg, bg, flags };
+}
+
+describe("Renderer", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  describe("setup", () => {
+    it("creates row elements for each row", () => {
+      const renderer = new Renderer(container);
+      renderer.setup(80, 24);
+      const rows = container.querySelectorAll(".term-row");
+      expect(rows).toHaveLength(24);
+    });
+
+    it("clears previous content on re-setup", () => {
+      const renderer = new Renderer(container);
+      renderer.setup(80, 24);
+      renderer.setup(40, 12);
+      const rows = container.querySelectorAll(".term-row");
+      expect(rows).toHaveLength(12);
+    });
+  });
+
+  describe("render", () => {
+    it("renders text content from bridge cells", () => {
+      const grid = [[makeCell("H"), makeCell("i")]];
+      const bridge = createMockBridge(2, 1, grid);
+      const renderer = new Renderer(container);
+      renderer.render(bridge as any);
+
+      const text = container.textContent;
+      expect(text).toContain("H");
+      expect(text).toContain("i");
+    });
+
+    it("applies cursor class to cursor position", () => {
+      const grid = [[makeCell("A"), makeCell("B")]];
+      const bridge = createMockBridge(2, 1, grid);
+      bridge.getCursor = () => ({ row: 0, col: 0, visible: true });
+      const renderer = new Renderer(container);
+      renderer.render(bridge as any);
+
+      const cursor = container.querySelector(".term-cursor");
+      expect(cursor).not.toBeNull();
+      expect(cursor?.textContent).toBe("A");
+    });
+
+    it("re-renders on resize", () => {
+      const bridge1 = createMockBridge(2, 1, [[makeCell("X")]]);
+      const renderer = new Renderer(container);
+      renderer.render(bridge1 as any);
+      expect(container.querySelectorAll(".term-row")).toHaveLength(1);
+
+      const bridge2 = createMockBridge(4, 3, []);
+      renderer.render(bridge2 as any);
+      expect(container.querySelectorAll(".term-row")).toHaveLength(3);
+    });
+
+    it("skips clean rows", () => {
+      const grid = [[makeCell("A")]];
+      const bridge = createMockBridge(1, 2, grid);
+      const renderer = new Renderer(container);
+      renderer.render(bridge as any);
+
+      const rows = container.querySelectorAll(".term-row");
+      const row1Text = rows[0].textContent;
+      expect(row1Text).toContain("A");
+    });
+
+    it("applies styled spans for colored cells", () => {
+      const grid = [[makeCell("C", 1, 256, 0)]];
+      const bridge = createMockBridge(1, 1, grid);
+      const renderer = new Renderer(container);
+      renderer.render(bridge as any);
+
+      const span = container.querySelector("span[style]");
+      expect(span).not.toBeNull();
+      expect(span?.getAttribute("style")).toContain("color:");
+    });
+
+    it("applies bold style via flags", () => {
+      const FLAG_BOLD = 0x01;
+      const grid = [[makeCell("B", 256, 256, FLAG_BOLD)]];
+      const bridge = createMockBridge(1, 1, grid);
+      const renderer = new Renderer(container);
+      renderer.render(bridge as any);
+
+      const span = container.querySelector("span[style]");
+      expect(span?.getAttribute("style")).toMatch(/font-weight:\s*bold/);
+    });
+  });
+});

--- a/packages/@wterm/dom/src/__tests__/setup.ts
+++ b/packages/@wterm/dom/src/__tests__/setup.ts
@@ -1,0 +1,38 @@
+import { vi } from "vitest";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    private callback: ResizeObserverCallback;
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+if (typeof globalThis.requestAnimationFrame === "undefined") {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => {
+    return setTimeout(() => cb(performance.now()), 0) as unknown as number;
+  };
+  globalThis.cancelAnimationFrame = (id: number) => {
+    clearTimeout(id);
+  };
+}
+
+vi.stubGlobal("getComputedStyle", (el: Element) => {
+  const orig = typeof window !== "undefined" ? window.getComputedStyle(el) : {};
+  return {
+    ...orig,
+    getPropertyValue: (prop: string) => {
+      if (prop === "--term-row-height") return "17";
+      return "";
+    },
+    paddingTop: "12",
+    paddingBottom: "12",
+    borderTopWidth: "0",
+    borderBottomWidth: "0",
+    boxSizing: "content-box",
+  };
+});

--- a/packages/@wterm/dom/vitest.config.ts
+++ b/packages/@wterm/dom/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.ts"],
+    setupFiles: ["src/__tests__/setup.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/__tests__/**"],
+    },
+  },
+});

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "pnpm build",
+    "test": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/@wterm/just-bash/src/__tests__/bash-shell.test.ts
+++ b/packages/@wterm/just-bash/src/__tests__/bash-shell.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { BashShell } from "../index.js";
+
+const mockExec = vi.fn();
+
+vi.mock("just-bash", () => {
+  class MockBash {
+    exec = mockExec;
+    constructor(_opts?: any) {}
+  }
+  return { Bash: MockBash };
+});
+
+describe("BashShell", () => {
+  let shell: BashShell;
+  let output: string[];
+  let write: (data: string) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    output = [];
+    write = (data: string) => output.push(data);
+    mockExec.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
+  });
+
+  describe("constructor", () => {
+    it("uses default options", () => {
+      shell = new BashShell();
+      expect(shell.cwd).toBe("/home/user");
+    });
+
+    it("accepts custom cwd", () => {
+      shell = new BashShell({ cwd: "/tmp" });
+      expect(shell.cwd).toBe("/tmp");
+    });
+
+    it("starts with null bash", () => {
+      shell = new BashShell();
+      expect(shell.bash).toBeNull();
+    });
+  });
+
+  describe("attach", () => {
+    it("initializes bash and shows prompt", async () => {
+      shell = new BashShell();
+      await shell.attach(write);
+
+      expect(shell.bash).not.toBeNull();
+      const joined = output.join("");
+      expect(joined).toContain("$");
+    });
+
+    it("shows greeting before prompt", async () => {
+      shell = new BashShell({ greeting: "Welcome!" });
+      await shell.attach(write);
+
+      expect(output[0]).toContain("Welcome!");
+    });
+
+    it("shows multi-line greeting", async () => {
+      shell = new BashShell({ greeting: ["Line 1", "Line 2"] });
+      await shell.attach(write);
+
+      const greeting = output[0];
+      expect(greeting).toContain("Line 1");
+      expect(greeting).toContain("Line 2");
+    });
+
+    it("shows no greeting when empty array", async () => {
+      shell = new BashShell({ greeting: [] });
+      await shell.attach(write);
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toContain("$");
+    });
+  });
+
+  describe("handleInput - printable characters", () => {
+    beforeEach(async () => {
+      shell = new BashShell();
+      await shell.attach(write);
+      output.length = 0;
+    });
+
+    it("echoes typed character", async () => {
+      await shell.handleInput("a");
+      expect(output).toContain("a");
+    });
+
+    it("inserts at cursor position", async () => {
+      await shell.handleInput("h");
+      await shell.handleInput("i");
+      expect(output.join("")).toContain("hi");
+    });
+  });
+
+  describe("handleInput - Enter", () => {
+    beforeEach(async () => {
+      shell = new BashShell();
+      await shell.attach(write);
+      output.length = 0;
+    });
+
+    it("sends CRLF and reprints prompt on empty", async () => {
+      await shell.handleInput("\r");
+      expect(output[0]).toBe("\r\n");
+      const joined = output.join("");
+      expect(joined).toContain("$");
+    });
+
+    it("executes command via bash.exec", async () => {
+      mockExec.mockResolvedValue({
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      await shell.handleInput("l");
+      await shell.handleInput("s");
+      await shell.handleInput("\r");
+
+      expect(mockExec).toHaveBeenCalled();
+      const calls = mockExec.mock.calls;
+      const execCall = calls.find(
+        (c: string[]) => typeof c[0] === "string" && c[0].includes("ls"),
+      );
+      expect(execCall).toBeDefined();
+    });
+
+    it("writes stdout to terminal", async () => {
+      mockExec
+        .mockResolvedValueOnce({
+          stdout: "file.txt\n",
+          stderr: "",
+          exitCode: 0,
+        })
+        .mockResolvedValueOnce({
+          stdout: "/home/user\n",
+          stderr: "",
+          exitCode: 0,
+        });
+
+      await shell.handleInput("l");
+      await shell.handleInput("s");
+      await shell.handleInput("\r");
+
+      const joined = output.join("");
+      expect(joined).toContain("file.txt");
+    });
+
+    it("writes stderr in red", async () => {
+      mockExec
+        .mockResolvedValueOnce({
+          stdout: "",
+          stderr: "not found",
+          exitCode: 1,
+        })
+        .mockResolvedValueOnce({
+          stdout: "/home/user\n",
+          stderr: "",
+          exitCode: 0,
+        });
+
+      await shell.handleInput("x");
+      await shell.handleInput("\r");
+
+      const joined = output.join("");
+      expect(joined).toContain("not found");
+      expect(joined).toContain("\x1b[31m");
+    });
+
+    it("adds command to history", async () => {
+      mockExec.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
+      await shell.handleInput("e");
+      await shell.handleInput("c");
+      await shell.handleInput("h");
+      await shell.handleInput("o");
+      await shell.handleInput("\r");
+
+      output.length = 0;
+      await shell.handleInput("\x1b[A");
+      const joined = output.join("");
+      expect(joined).toContain("echo");
+    });
+  });
+
+  describe("handleInput - backspace", () => {
+    beforeEach(async () => {
+      shell = new BashShell();
+      await shell.attach(write);
+      output.length = 0;
+    });
+
+    it("deletes character before cursor", async () => {
+      await shell.handleInput("a");
+      await shell.handleInput("b");
+      output.length = 0;
+      await shell.handleInput("\x7f");
+      expect(output.join("")).toContain("\b");
+    });
+
+    it("does nothing at start of line", async () => {
+      await shell.handleInput("\x7f");
+      expect(output).toHaveLength(0);
+    });
+  });
+
+  describe("handleInput - arrow keys", () => {
+    beforeEach(async () => {
+      shell = new BashShell();
+      await shell.attach(write);
+      output.length = 0;
+    });
+
+    it("moves cursor left", async () => {
+      await shell.handleInput("a");
+      output.length = 0;
+      await shell.handleInput("\x1b[D");
+      expect(output.join("")).toContain("\x1b[D");
+    });
+
+    it("moves cursor right", async () => {
+      await shell.handleInput("a");
+      await shell.handleInput("\x1b[D");
+      output.length = 0;
+      await shell.handleInput("\x1b[C");
+      expect(output.join("")).toContain("\x1b[C");
+    });
+
+    it("does not move left past start", async () => {
+      await shell.handleInput("\x1b[D");
+      expect(output).toHaveLength(0);
+    });
+
+    it("does not move right past end", async () => {
+      await shell.handleInput("\x1b[C");
+      expect(output).toHaveLength(0);
+    });
+  });
+
+  describe("handleInput - history navigation", () => {
+    beforeEach(async () => {
+      shell = new BashShell();
+      await shell.attach(write);
+      mockExec.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
+      await shell.handleInput("first");
+      await shell.handleInput("\r");
+      await shell.handleInput("second");
+      await shell.handleInput("\r");
+      output.length = 0;
+    });
+
+    it("navigates up to previous command", async () => {
+      await shell.handleInput("\x1b[A");
+      const joined = output.join("");
+      expect(joined).toContain("second");
+    });
+
+    it("navigates up twice to older command", async () => {
+      await shell.handleInput("\x1b[A");
+      await shell.handleInput("\x1b[A");
+      const joined = output.join("");
+      expect(joined).toContain("first");
+    });
+
+    it("navigates down to clear line", async () => {
+      await shell.handleInput("\x1b[A");
+      output.length = 0;
+      await shell.handleInput("\x1b[B");
+      const joined = output.join("");
+      expect(joined).toContain("\x1b[K");
+    });
+  });
+
+  describe("handleInput - control sequences", () => {
+    beforeEach(async () => {
+      shell = new BashShell();
+      await shell.attach(write);
+      output.length = 0;
+    });
+
+    it("Ctrl+U clears the line", async () => {
+      await shell.handleInput("hello");
+      output.length = 0;
+      await shell.handleInput("\x15");
+      const joined = output.join("");
+      expect(joined).toContain("\x1b[K");
+    });
+
+    it("Ctrl+C aborts and reprints prompt", async () => {
+      await shell.handleInput("partial");
+      output.length = 0;
+      await shell.handleInput("\x03");
+      const joined = output.join("");
+      expect(joined).toContain("^C");
+      expect(joined).toContain("$");
+    });
+
+    it("Ctrl+A moves to beginning of line", async () => {
+      await shell.handleInput("text");
+      output.length = 0;
+      await shell.handleInput("\x01");
+      const joined = output.join("");
+      expect(joined).toContain("\x1b[");
+    });
+
+    it("Ctrl+E moves to end of line", async () => {
+      await shell.handleInput("text");
+      await shell.handleInput("\x01");
+      output.length = 0;
+      await shell.handleInput("\x05");
+      const joined = output.join("");
+      expect(joined).toContain("\x1b[");
+    });
+
+    it("Ctrl+L clears screen and reprints", async () => {
+      await shell.handleInput("cmd");
+      output.length = 0;
+      await shell.handleInput("\x0c");
+      const joined = output.join("");
+      expect(joined).toContain("\x1b[2J");
+      expect(joined).toContain("cmd");
+    });
+  });
+
+  describe("handleInput - line continuation", () => {
+    beforeEach(async () => {
+      shell = new BashShell();
+      await shell.attach(write);
+      output.length = 0;
+    });
+
+    it("buffers continued lines ending with backslash", async () => {
+      await shell.handleInput("echo \\");
+      await shell.handleInput("\r");
+      const joined = output.join("");
+      expect(joined).toContain("> ");
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleInput - multi-char paste", () => {
+    beforeEach(async () => {
+      shell = new BashShell();
+      await shell.attach(write);
+      output.length = 0;
+    });
+
+    it("processes pasted multi-character strings", async () => {
+      await shell.handleInput("abc");
+      const joined = output.join("");
+      expect(joined).toContain("a");
+      expect(joined).toContain("b");
+      expect(joined).toContain("c");
+    });
+  });
+
+  describe("custom prompt", () => {
+    it("uses custom prompt function", async () => {
+      shell = new BashShell({
+        prompt: (cwd) => `[${cwd}]> `,
+      });
+      await shell.attach(write);
+      const joined = output.join("");
+      expect(joined).toContain("[/home/user]> ");
+    });
+  });
+});

--- a/packages/@wterm/just-bash/vitest.config.ts
+++ b/packages/@wterm/just-bash/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/__tests__/**"],
+    },
+  },
+});

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "pnpm build",
+    "test": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/@wterm/markdown/src/__tests__/markdown.test.ts
+++ b/packages/@wterm/markdown/src/__tests__/markdown.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { MarkdownRenderer } from "../index.js";
+
+const ESC = "\x1b[";
+const RESET = `${ESC}0m`;
+const BOLD = `${ESC}1m`;
+const DIM = `${ESC}2m`;
+const ITALIC = `${ESC}3m`;
+const UNDERLINE = `${ESC}4m`;
+const CYAN = `${ESC}36m`;
+const GREEN = `${ESC}32m`;
+const BRIGHT_WHITE = `${ESC}97m`;
+const CR_LF = "\r\n";
+
+function stripAnsi(str: string): string {
+  return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("MarkdownRenderer", () => {
+  let renderer: MarkdownRenderer;
+
+  beforeEach(() => {
+    renderer = new MarkdownRenderer();
+  });
+
+  describe("constructor", () => {
+    it("uses default width of 80", () => {
+      const r = new MarkdownRenderer();
+      const result = r.push("---\n");
+      const plain = stripAnsi(result);
+      expect(plain).toContain("─");
+    });
+
+    it("accepts custom width", () => {
+      const r = new MarkdownRenderer({ width: 20 });
+      const result = r.push("---\n");
+      const rule = stripAnsi(result).replace(/\r\n/g, "");
+      expect(rule.length).toBeLessThanOrEqual(20);
+    });
+  });
+
+  describe("headings", () => {
+    it("renders h1 with bold bright white", () => {
+      const result = renderer.push("# Hello World\n");
+      expect(result).toContain(BOLD);
+      expect(result).toContain(BRIGHT_WHITE);
+      expect(result).toContain("Hello World");
+      expect(result).toContain(RESET);
+    });
+
+    it("renders h2 with bold bright white", () => {
+      const result = renderer.push("## Section\n");
+      expect(result).toContain(BOLD);
+      expect(result).toContain(BRIGHT_WHITE);
+      expect(result).toContain("Section");
+    });
+
+    it("renders h3 with bold only (no bright white)", () => {
+      const result = renderer.push("### Subsection\n");
+      expect(result).toContain(BOLD);
+      expect(result).not.toContain(BRIGHT_WHITE);
+      expect(result).toContain("Subsection");
+    });
+
+    it("renders h4-h6 with bold only", () => {
+      for (const level of [4, 5, 6]) {
+        const r = new MarkdownRenderer();
+        const hashes = "#".repeat(level);
+        const result = r.push(`${hashes} Heading ${level}\n`);
+        expect(result).toContain(BOLD);
+        expect(result).not.toContain(BRIGHT_WHITE);
+        expect(result).toContain(`Heading ${level}`);
+      }
+    });
+  });
+
+  describe("fenced code blocks", () => {
+    it("renders a code block with dim styling", () => {
+      const input = "```\nconsole.log('hi');\n```\n";
+      const result = renderer.push(input);
+      expect(result).toContain(DIM);
+      expect(result).toContain("console.log('hi');");
+      expect(result).toContain(RESET);
+    });
+
+    it("handles code blocks with language tags", () => {
+      const input = "```typescript\nconst x = 1;\n```\n";
+      const result = renderer.push(input);
+      expect(result).toContain("const x = 1;");
+    });
+
+    it("renders multi-line code blocks", () => {
+      const input = "```\nline 1\nline 2\nline 3\n```\n";
+      const result = renderer.push(input);
+      expect(result).toContain("line 1");
+      expect(result).toContain("line 2");
+      expect(result).toContain("line 3");
+    });
+
+    it("includes decorative rules around code blocks", () => {
+      const input = "```\ncode\n```\n";
+      const result = renderer.push(input);
+      const plain = stripAnsi(result);
+      expect(plain).toContain("─");
+    });
+  });
+
+  describe("inline formatting", () => {
+    it("renders bold text with ** markers", () => {
+      const result = renderer.push("This is **bold** text\n");
+      expect(result).toContain(BOLD);
+      expect(result).toContain("bold");
+    });
+
+    it("renders bold text with __ markers", () => {
+      const result = renderer.push("This is __bold__ text\n");
+      expect(result).toContain(BOLD);
+      expect(result).toContain("bold");
+    });
+
+    it("renders italic text with * marker", () => {
+      const result = renderer.push("This is *italic* text\n");
+      expect(result).toContain(ITALIC);
+      expect(result).toContain("italic");
+    });
+
+    it("renders italic text with _ marker", () => {
+      const result = renderer.push("This is _italic_ text\n");
+      expect(result).toContain(ITALIC);
+      expect(result).toContain("italic");
+    });
+
+    it("renders inline code with backticks", () => {
+      const result = renderer.push("Use `console.log` here\n");
+      expect(result).toContain(CYAN);
+      expect(result).toContain("console.log");
+    });
+
+    it("renders links with text and URL", () => {
+      const result = renderer.push("Visit [Example](https://example.com)\n");
+      expect(result).toContain(UNDERLINE);
+      expect(result).toContain(GREEN);
+      expect(result).toContain("Example");
+      expect(result).toContain("https://example.com");
+    });
+
+    it("omits URL display for anchor links", () => {
+      const result = renderer.push("See [section](#anchor)\n");
+      expect(result).toContain("section");
+      expect(result).not.toContain("#anchor");
+    });
+  });
+
+  describe("lists", () => {
+    it("renders unordered list items with - marker", () => {
+      const result = renderer.push("- Item one\n- Item two\n");
+      const plain = stripAnsi(result);
+      expect(plain).toContain("* Item one");
+      expect(plain).toContain("* Item two");
+    });
+
+    it("renders unordered list items with * marker", () => {
+      const result = renderer.push("* First\n* Second\n");
+      const plain = stripAnsi(result);
+      expect(plain).toContain("* First");
+      expect(plain).toContain("* Second");
+    });
+
+    it("renders ordered list items", () => {
+      const result = renderer.push("1. First\n2. Second\n");
+      const plain = stripAnsi(result);
+      expect(plain).toContain("1. First");
+      expect(plain).toContain("2. Second");
+    });
+  });
+
+  describe("blockquotes", () => {
+    it("renders blockquote with vertical bar prefix", () => {
+      const result = renderer.push("> This is a quote\n");
+      expect(result).toContain(DIM);
+      expect(result).toContain("│");
+      expect(result).toContain("This is a quote");
+    });
+
+    it("renders empty blockquote line", () => {
+      const result = renderer.push(">\n");
+      expect(result).toContain("│");
+    });
+  });
+
+  describe("horizontal rules", () => {
+    it("renders --- as a horizontal rule", () => {
+      const result = renderer.push("---\n");
+      expect(result).toContain(DIM);
+      const plain = stripAnsi(result);
+      expect(plain).toContain("─");
+    });
+
+    it("renders *** as a horizontal rule", () => {
+      const result = renderer.push("***\n");
+      const plain = stripAnsi(result);
+      expect(plain).toContain("─");
+    });
+
+    it("renders ___ as a horizontal rule", () => {
+      const result = renderer.push("___\n");
+      const plain = stripAnsi(result);
+      expect(plain).toContain("─");
+    });
+  });
+
+  describe("blank lines", () => {
+    it("collapses consecutive blank lines", () => {
+      const result = renderer.push("Hello\n\n\n\nWorld\n");
+      const crlfCount = result.split(CR_LF).length - 1;
+      const singleBlank = renderer.push.length;
+      expect(result).toContain("Hello");
+      expect(result).toContain("World");
+      expect(crlfCount).toBeLessThan(6);
+    });
+  });
+
+  describe("streaming", () => {
+    it("buffers incomplete lines", () => {
+      const result1 = renderer.push("Hello ");
+      expect(result1).toBe("");
+
+      const result2 = renderer.push("World\n");
+      expect(result2).toContain("Hello World");
+    });
+
+    it("handles multi-chunk streaming", () => {
+      renderer.push("# ");
+      renderer.push("Hel");
+      const result = renderer.push("lo\n");
+      expect(result).toContain(BOLD);
+      expect(result).toContain("Hello");
+    });
+
+    it("handles streaming across code block boundaries", () => {
+      const r1 = renderer.push("```\n");
+      expect(r1).toBe("");
+
+      const r2 = renderer.push("code line\n");
+      expect(r2).toBe("");
+
+      const r3 = renderer.push("```\n");
+      expect(r3).toContain("code line");
+    });
+  });
+
+  describe("flush", () => {
+    it("emits remaining buffered content", () => {
+      renderer.push("Incomplete line");
+      const result = renderer.flush();
+      expect(result).toContain("Incomplete line");
+    });
+
+    it("flushes unclosed code blocks", () => {
+      renderer.push("```\norphaned code\n");
+      const result = renderer.flush();
+      expect(result).toContain("orphaned code");
+    });
+
+    it("returns empty string when buffer is empty", () => {
+      renderer.push("Complete line\n");
+      const result = renderer.flush();
+      expect(result).toBe("");
+    });
+  });
+
+  describe("paragraph text", () => {
+    it("renders plain paragraph text with CRLF", () => {
+      const result = renderer.push("Just a normal paragraph line.\n");
+      expect(result).toContain("Just a normal paragraph line.");
+      expect(result.endsWith(CR_LF)).toBe(true);
+    });
+  });
+});

--- a/packages/@wterm/markdown/vitest.config.ts
+++ b/packages/@wterm/markdown/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/__tests__/**"],
+    },
+  },
+});

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -24,12 +24,19 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "pnpm build",
+    "test": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
     "@internal/ts": "workspace:*",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@wterm/dom": "^0.1.7",
+    "jsdom": "^29.0.2",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "typescript": "^6.0.2"
   },
   "peerDependencies": {

--- a/packages/@wterm/react/src/__tests__/Terminal.test.tsx
+++ b/packages/@wterm/react/src/__tests__/Terminal.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import React, { createRef } from "react";
+import type { TerminalHandle } from "../Terminal.js";
+import { useTerminal } from "../useTerminal.js";
+
+let lastWTermInstance: any = null;
+
+vi.mock("@wterm/dom", () => {
+  const mockWTerm = vi.fn().mockImplementation(function (
+    this: any,
+    el: HTMLElement,
+    options: any,
+  ) {
+    this.element = el;
+    this.bridge = null;
+    this.cols = options?.cols ?? 80;
+    this.rows = options?.rows ?? 24;
+    this.onData = options?.onData ?? null;
+    this.onTitle = options?.onTitle ?? null;
+    this.onResize = options?.onResize ?? null;
+    this.autoResize = options?.autoResize !== false;
+    this.write = vi.fn();
+    this.resize = vi.fn();
+    this.focus = vi.fn();
+    this.destroy = vi.fn();
+    this.init = vi.fn().mockImplementation(async () => {
+      this.bridge = {};
+      return this;
+    });
+    lastWTermInstance = this;
+  });
+
+  return {
+    WTerm: mockWTerm,
+    Renderer: vi.fn(),
+    InputHandler: vi.fn(),
+  };
+});
+
+describe("Terminal component", () => {
+  beforeEach(() => {
+    lastWTermInstance = null;
+    vi.clearAllMocks();
+  });
+
+  async function renderTerminal(props: Record<string, any> = {}) {
+    const Terminal = (await import("../Terminal.js")).default;
+    return render(<Terminal {...props} />);
+  }
+
+  it("renders a div with terminal role", async () => {
+    await renderTerminal();
+    const el = screen.getByRole("textbox");
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveAttribute("aria-label", "Terminal");
+    expect(el).toHaveAttribute("aria-roledescription", "terminal");
+  });
+
+  it("applies className prop", async () => {
+    const { container } = await renderTerminal({ className: "custom" });
+    const el = container.querySelector("[role='textbox']")!;
+    expect(el.className).toContain("custom");
+  });
+
+  it("applies theme class", async () => {
+    const { container } = await renderTerminal({ theme: "dark" });
+    const el = container.querySelector("[role='textbox']")!;
+    expect(el.className).toContain("theme-dark");
+  });
+
+  it("creates WTerm instance on mount", async () => {
+    const { WTerm } = await import("@wterm/dom");
+    await renderTerminal();
+    expect(WTerm).toHaveBeenCalled();
+  });
+
+  it("calls init on mount", async () => {
+    await renderTerminal();
+    await act(async () => {});
+    expect(lastWTermInstance).not.toBeNull();
+    expect(lastWTermInstance.init).toHaveBeenCalled();
+  });
+
+  it("calls onReady after init", async () => {
+    const onReady = vi.fn();
+    await renderTerminal({ onReady });
+    await act(async () => {});
+    expect(onReady).toHaveBeenCalled();
+  });
+
+  it("calls onError on init failure", async () => {
+    const { WTerm } = await import("@wterm/dom");
+    (WTerm as any).mockImplementationOnce(function (
+      this: any,
+      el: HTMLElement,
+    ) {
+      this.element = el;
+      this.bridge = null;
+      this.cols = 80;
+      this.rows = 24;
+      this.onData = null;
+      this.onTitle = null;
+      this.onResize = null;
+      this.autoResize = true;
+      this.write = vi.fn();
+      this.resize = vi.fn();
+      this.focus = vi.fn();
+      this.destroy = vi.fn();
+      this.init = vi.fn().mockRejectedValue(new Error("WASM failed"));
+      lastWTermInstance = this;
+    });
+
+    const onError = vi.fn();
+    await renderTerminal({ onError });
+    await act(async () => {});
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("calls destroy on unmount", async () => {
+    const { unmount } = await renderTerminal();
+    await act(async () => {});
+    const instance = lastWTermInstance;
+    unmount();
+    expect(instance.destroy).toHaveBeenCalled();
+  });
+
+  it("exposes imperative handle via ref", async () => {
+    const ref = createRef<TerminalHandle>();
+    const Terminal = (await import("../Terminal.js")).default;
+    render(<Terminal ref={ref} />);
+    await act(async () => {});
+
+    expect(ref.current).not.toBeNull();
+    expect(typeof ref.current!.write).toBe("function");
+    expect(typeof ref.current!.resize).toBe("function");
+    expect(typeof ref.current!.focus).toBe("function");
+  });
+
+  it("delegates write through imperative handle", async () => {
+    const ref = createRef<TerminalHandle>();
+    const Terminal = (await import("../Terminal.js")).default;
+    render(<Terminal ref={ref} />);
+    await act(async () => {});
+
+    ref.current!.write("test data");
+    expect(lastWTermInstance.write).toHaveBeenCalledWith("test data");
+  });
+
+  it("delegates resize through imperative handle", async () => {
+    const ref = createRef<TerminalHandle>();
+    const Terminal = (await import("../Terminal.js")).default;
+    render(<Terminal ref={ref} />);
+    await act(async () => {});
+
+    ref.current!.resize(120, 40);
+    expect(lastWTermInstance.resize).toHaveBeenCalledWith(120, 40);
+  });
+
+  it("delegates focus through imperative handle", async () => {
+    const ref = createRef<TerminalHandle>();
+    const Terminal = (await import("../Terminal.js")).default;
+    render(<Terminal ref={ref} />);
+    await act(async () => {});
+
+    ref.current!.focus();
+    expect(lastWTermInstance.focus).toHaveBeenCalled();
+  });
+});
+
+describe("useTerminal", () => {
+  it("returns ref, write, resize, focus", () => {
+    let result: ReturnType<typeof useTerminal> | null = null;
+
+    function TestComponent() {
+      result = useTerminal();
+      return <div />;
+    }
+
+    render(<TestComponent />);
+    expect(result).not.toBeNull();
+    expect(result!.ref).toBeDefined();
+    expect(typeof result!.write).toBe("function");
+    expect(typeof result!.resize).toBe("function");
+    expect(typeof result!.focus).toBe("function");
+  });
+
+  it("write is a stable callback", () => {
+    const writes: Function[] = [];
+
+    function TestComponent() {
+      const { write } = useTerminal();
+      writes.push(write);
+      return <div />;
+    }
+
+    const { rerender } = render(<TestComponent />);
+    rerender(<TestComponent />);
+    expect(writes[0]).toBe(writes[1]);
+  });
+});

--- a/packages/@wterm/react/src/__tests__/setup.ts
+++ b/packages/@wterm/react/src/__tests__/setup.ts
@@ -1,0 +1,19 @@
+import "@testing-library/jest-dom/vitest";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    constructor(_callback: ResizeObserverCallback) {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+if (typeof globalThis.requestAnimationFrame === "undefined") {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => {
+    return setTimeout(() => cb(performance.now()), 0) as unknown as number;
+  };
+  globalThis.cancelAnimationFrame = (id: number) => {
+    clearTimeout(id);
+  };
+}

--- a/packages/@wterm/react/vitest.config.ts
+++ b/packages/@wterm/react/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.tsx"],
+    setupFiles: ["src/__tests__/setup.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts", "src/**/*.tsx"],
+      exclude: ["src/**/*.test.tsx", "src/**/__tests__/**"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,12 +13,18 @@ importers:
 
   .:
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.4
+        version: 4.1.4(vitest@4.1.4)
       prettier:
         specifier: ^3.8.2
         version: 3.8.2
       turbo:
         specifier: ^2.9.6
         version: 2.9.6
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/docs:
     dependencies:
@@ -371,6 +377,9 @@ importers:
       '@internal/ts':
         specifier: workspace:*
         version: link:../../@internal/ts
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -397,31 +406,42 @@ importers:
         version: 6.0.2
 
   packages/@wterm/react:
-    dependencies:
-      '@wterm/dom':
-        specifier: workspace:*
-        version: link:../dom
-      react:
-        specifier: ^18.0.0 || ^19.0.0
-        version: 19.2.5
-      react-dom:
-        specifier: ^18.0.0 || ^19.0.0
-        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@internal/ts':
         specifier: workspace:*
         version: link:../../@internal/ts
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@wterm/dom':
+        specifier: ^0.1.7
+        version: 0.1.7
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@ai-sdk/gateway@3.0.96':
     resolution: {integrity: sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==}
@@ -451,6 +471,21 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.10':
+    resolution: {integrity: sha512-KyOb19eytNSELkmdqzZZUXWCU25byIlOld5qVFg0RYdS0T3tt7jeDByxk9hIAC73frclD8GKrHttr0SUjKCCdQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -608,11 +643,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@chevrotain/cst-dts-gen@12.0.0':
     resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
@@ -628,6 +671,42 @@ packages:
 
   '@chevrotain/utils@12.0.0':
     resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -844,6 +923,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1135,6 +1223,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.3':
     resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
 
@@ -1240,6 +1334,9 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1931,6 +2028,98 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2066,6 +2255,29 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -2108,6 +2320,12 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -2204,6 +2422,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -2443,6 +2664,50 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
+    peerDependencies:
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
+  '@wterm/core@0.1.7':
+    resolution: {integrity: sha512-uP8R/OxO/cZUVOWD2q9SLgRTjqH6Ovd3se3SOJvwTi13yJazUF9hGlTrybLgNi4hmuGTHxHPSDSHvQrgf0KEeg==}
+
+  '@wterm/dom@0.1.7':
+    resolution: {integrity: sha512-235hVbza23+OIYuOror1y7L8MknISTg5yEobNqnNgUmUJ8GjCz5ertTZpZp6zE/1x4Ik2iBd8DjeG5J0g8MR+A==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -2493,12 +2758,19 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2539,12 +2811,19 @@ packages:
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -2599,6 +2878,9 @@ packages:
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -2659,6 +2941,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2809,6 +3095,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -2981,6 +3274,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -3015,6 +3312,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -3091,6 +3391,12 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dompurify@3.4.0:
     resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
@@ -3158,6 +3464,9 @@ packages:
   es-iterator-helpers@1.3.2:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3370,6 +3679,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.2:
     resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
@@ -3658,6 +3971,13 @@ packages:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -3706,6 +4026,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3854,6 +4178,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -3927,6 +4254,18 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -3938,12 +4277,24 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -4124,6 +4475,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -4132,8 +4487,19 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -4203,6 +4569,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -4350,6 +4719,10 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -4521,6 +4894,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -4592,6 +4968,9 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -4690,6 +5069,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -4765,6 +5148,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -4820,6 +5206,10 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -4905,6 +5295,11 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -4939,6 +5334,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -5015,6 +5414,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5063,9 +5465,15 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -5145,6 +5553,10 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -5195,6 +5607,9 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -5228,6 +5643,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -5235,6 +5653,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.28:
     resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
@@ -5258,6 +5680,10 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -5370,6 +5796,10 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -5467,6 +5897,90 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -5487,12 +6001,28 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5518,6 +6048,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -5550,6 +6085,13 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -5609,6 +6151,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@ai-sdk/gateway@3.0.96(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -5643,6 +6187,26 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.0.10':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5857,9 +6421,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@borewit/text-codec@0.2.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@chevrotain/cst-dts-gen@12.0.0':
     dependencies:
@@ -5875,6 +6445,30 @@ snapshots:
   '@chevrotain/types@12.0.0': {}
 
   '@chevrotain/utils@12.0.0': {}
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -6034,6 +6628,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -6330,6 +6928,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@16.2.3': {}
 
   '@next/eslint-plugin-next@16.2.3':
@@ -6399,6 +7004,8 @@ snapshots:
   '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@oxc-project/types@0.124.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -7147,6 +7754,57 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -7268,6 +7926,36 @@ snapshots:
       postcss: 8.5.9
       tailwindcss: 4.2.2
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -7305,6 +7993,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -7426,6 +8121,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -7658,6 +8355,68 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.4
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.3(@types/node@25.6.0)(typescript@6.0.2)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@wterm/core@0.1.7': {}
+
+  '@wterm/dom@0.1.7':
+    dependencies:
+      '@wterm/core': 0.1.7
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -7705,11 +8464,17 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -7784,11 +8549,19 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -7825,6 +8598,10 @@ snapshots:
   bcrypt-pbkdf@1.0.2:
     dependencies:
       tweetnacl: 0.14.5
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bl@4.1.0:
     dependencies:
@@ -7905,6 +8682,8 @@ snapshots:
   caniuse-lite@1.0.30001788: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -8030,6 +8809,13 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
 
@@ -8223,6 +9009,13 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@7.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -8252,6 +9045,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -8313,6 +9108,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dompurify@3.4.0:
     optionalDependencies:
@@ -8443,6 +9242,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@2.0.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -8520,7 +9321,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.3
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -8563,7 +9364,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8578,11 +9379,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      get-tsconfig: 4.13.7
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
@@ -8600,7 +9426,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8629,7 +9455,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8839,6 +9665,8 @@ snapshots:
 
   expand-template@2.0.3:
     optional: true
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
@@ -9235,6 +10063,14 @@ snapshots:
 
   hono@4.12.12: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
@@ -9278,6 +10114,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -9406,6 +10244,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -9467,6 +10307,19 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -9480,11 +10333,39 @@ snapshots:
 
   jose@6.2.2: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.2(@noble/hashes@1.8.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.0.10
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -9652,6 +10533,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.3.5: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -9660,9 +10543,21 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   markdown-extensions@2.0.0: {}
 
@@ -9836,6 +10731,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -10151,6 +11048,8 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -10339,6 +11238,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -10440,6 +11341,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -10523,6 +11428,12 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.2: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-ms@9.3.0:
     dependencies:
@@ -10661,6 +11572,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -10733,6 +11646,11 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -10860,6 +11778,27 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
+  rolldown@1.0.0-rc.15:
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -10908,6 +11847,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -11088,6 +12031,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -11128,7 +12073,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -11254,6 +12203,10 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1:
     optional: true
 
@@ -11294,6 +12247,8 @@ snapshots:
       react: 19.2.5
       use-sync-external-store: 1.6.0(react@19.2.5)
 
+  symbol-tree@3.2.4: {}
+
   tagged-tag@1.0.0: {}
 
   tailwind-merge@3.5.0: {}
@@ -11327,12 +12282,16 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.28: {}
 
@@ -11355,6 +12314,10 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -11492,6 +12455,8 @@ snapshots:
 
   undici-types@7.19.2: {}
 
+  undici@7.25.0: {}
+
   unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
@@ -11613,6 +12578,51 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -11630,9 +12640,25 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -11683,6 +12709,11 @@ snapshots:
     dependencies:
       isexe: 3.1.5
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@6.2.0:
@@ -11705,6 +12736,10 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,9 @@
     "lint": {
       "dependsOn": ["^build"]
     },
+    "test": {
+      "dependsOn": ["^build"]
+    },
     "type-check": {
       "dependsOn": ["^build"]
     }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,9 @@
+import { defineWorkspace } from "vitest/config";
+
+export default defineWorkspace([
+  "packages/@wterm/markdown",
+  "packages/@wterm/core",
+  "packages/@wterm/dom",
+  "packages/@wterm/react",
+  "packages/@wterm/just-bash",
+]);


### PR DESCRIPTION
## Summary

- Set up Vitest workspace with per-package configs (`node` for markdown/core/just-bash, `jsdom` for dom/react)
- Added 165 tests covering all five `@wterm/*` packages
- Wired tests into Turbo (`dependsOn: ["^build"]`) and CI
- Configured V8 coverage with `text` + `lcov` reporters

### Test breakdown

| Package | Tests | Highlights |
|---|---|---|
| `@wterm/markdown` | 33 | MarkdownRenderer push/flush, headings, code blocks, inline formatting, lists, blockquotes, streaming |
| `@wterm/core` | 53 | WasmBridge with real WASM (init, write, cursor, resize, SGR, modes, title, scrollback); WebSocketTransport with mocked WebSocket (connect, send, reconnect backoff, buffering) |
| `@wterm/dom` | 34 | Renderer (setup, render, cursor, styled spans); InputHandler (key mapping, paste, bracketed paste, destroy) |
| `@wterm/react` | 14 | Terminal component (render, lifecycle, imperative handle); useTerminal hook (stable callbacks) |
| `@wterm/just-bash` | 31 | BashShell (attach, greeting, input, exec, backspace, arrows, history, Ctrl sequences, line continuation) |