### PR TITLE
Add docs pages for Just Bash, Markdown, and Core / Advanced

### DIFF
--- a/apps/docs/src/app/core/layout.tsx
+++ b/apps/docs/src/app/core/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("core");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/docs/src/app/core/page.mdx
+++ b/apps/docs/src/app/core/page.mdx
@@ -1,0 +1,284 @@
+# Core / Advanced
+
+`@wterm/core` provides the headless terminal engine and WebSocket transport. Use it when you need direct access to the WASM bridge for a custom renderer, headless testing, or a server-connected terminal without the DOM layer.
+
+## Install
+
+```bash
+npm install @wterm/core
+```
+
+## WasmBridge
+
+Low-level interface to the Zig/WASM terminal state machine. The bridge manages a virtual terminal grid in WASM memory — you write data in and read cells, cursor state, and scrollback out.
+
+### Loading
+
+```ts
+import { WasmBridge } from "@wterm/core";
+
+// Use the embedded WASM binary (default, zero-config)
+const bridge = await WasmBridge.load();
+
+// Or fetch from a URL (useful for CDN caching)
+const bridge = await WasmBridge.load("/wterm.wasm");
+```
+
+When no URL is provided, the ~12 KB WASM binary is decoded from a base64 string inlined in the package. Pass a URL when you want to serve the binary separately for caching or CDN use.
+
+### Methods
+
+<table>
+  <thead>
+    <tr>
+      <th>Method</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WasmBridge.load(url?): Promise&lt;WasmBridge&gt;</code></td>
+      <td>Load the WASM binary and return a new bridge instance</td>
+    </tr>
+    <tr>
+      <td><code>init(cols, rows)</code></td>
+      <td>Initialize the terminal grid</td>
+    </tr>
+    <tr>
+      <td><code>writeString(str)</code></td>
+      <td>Write a UTF-8 string (including escape sequences) to the terminal</td>
+    </tr>
+    <tr>
+      <td><code>writeRaw(data: Uint8Array)</code></td>
+      <td>Write raw bytes to the terminal (chunked to 8192 bytes internally)</td>
+    </tr>
+    <tr>
+      <td><code>resize(cols, rows)</code></td>
+      <td>Resize the terminal grid</td>
+    </tr>
+    <tr>
+      <td><code>getCell(row, col): CellData</code></td>
+      <td>Get cell data at a grid position</td>
+    </tr>
+    <tr>
+      <td><code>getCursor(): CursorState</code></td>
+      <td>Get current cursor position and visibility</td>
+    </tr>
+    <tr>
+      <td><code>getCols() / getRows()</code></td>
+      <td>Get current grid dimensions</td>
+    </tr>
+    <tr>
+      <td><code>isDirtyRow(row): boolean</code></td>
+      <td>Check if a row has changed since last <code>clearDirty()</code></td>
+    </tr>
+    <tr>
+      <td><code>clearDirty()</code></td>
+      <td>Reset all dirty-row flags</td>
+    </tr>
+    <tr>
+      <td><code>getTitle(): string | null</code></td>
+      <td>Get pending title change (via OSC escape), or <code>null</code> if unchanged</td>
+    </tr>
+    <tr>
+      <td><code>getResponse(): string | null</code></td>
+      <td>Get pending host response (e.g. DSR), or <code>null</code>. Reading clears the buffer.</td>
+    </tr>
+    <tr>
+      <td><code>getScrollbackCount(): number</code></td>
+      <td>Number of lines in the scrollback buffer</td>
+    </tr>
+    <tr>
+      <td><code>getScrollbackCell(offset, col): CellData</code></td>
+      <td>Get cell data from a scrollback line</td>
+    </tr>
+    <tr>
+      <td><code>getScrollbackLineLen(offset): number</code></td>
+      <td>Get the length of a scrollback line</td>
+    </tr>
+    <tr>
+      <td><code>cursorKeysApp(): boolean</code></td>
+      <td>Whether cursor keys are in application mode</td>
+    </tr>
+    <tr>
+      <td><code>bracketedPaste(): boolean</code></td>
+      <td>Whether bracketed paste mode is active</td>
+    </tr>
+    <tr>
+      <td><code>usingAltScreen(): boolean</code></td>
+      <td>Whether the alternate screen buffer is active</td>
+    </tr>
+  </tbody>
+</table>
+
+### Types
+
+```ts
+interface CellData {
+  char: number;   // Unicode code point
+  fg: number;     // Foreground color index (256 = default)
+  bg: number;     // Background color index (256 = default)
+  flags: number;  // Style flags (bold, italic, underline, etc.)
+}
+
+interface CursorState {
+  row: number;
+  col: number;
+  visible: boolean;
+}
+```
+
+### Example
+
+Headless usage — load the bridge, write data, and read cells back:
+
+```ts
+import { WasmBridge } from "@wterm/core";
+
+const bridge = await WasmBridge.load();
+bridge.init(80, 24);
+
+bridge.writeString("Hello, world!\r\n");
+bridge.writeString("\x1b[1;31mRed bold text\x1b[0m");
+
+for (let col = 0; col < 13; col++) {
+  const cell = bridge.getCell(0, col);
+  process.stdout.write(String.fromCodePoint(cell.char));
+}
+// → "Hello, world!"
+
+const cursor = bridge.getCursor();
+// → { row: 1, col: 13, visible: true }
+```
+
+## WebSocketTransport
+
+Connect to a PTY backend over WebSocket with automatic reconnection and send buffering.
+
+### Options
+
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>url</code></td>
+      <td><code>string</code></td>
+      <td>—</td>
+      <td>WebSocket server URL</td>
+    </tr>
+    <tr>
+      <td><code>reconnect</code></td>
+      <td><code>boolean</code></td>
+      <td><code>true</code></td>
+      <td>Auto-reconnect on disconnect with exponential backoff</td>
+    </tr>
+    <tr>
+      <td><code>maxReconnectDelay</code></td>
+      <td><code>number</code></td>
+      <td><code>30000</code></td>
+      <td>Maximum delay between reconnection attempts (ms)</td>
+    </tr>
+    <tr>
+      <td><code>onData</code></td>
+      <td><code>(data: Uint8Array | string) =&gt; void</code></td>
+      <td>—</td>
+      <td>Called when data is received from the server</td>
+    </tr>
+    <tr>
+      <td><code>onOpen</code></td>
+      <td><code>() =&gt; void</code></td>
+      <td>—</td>
+      <td>Called when the connection opens</td>
+    </tr>
+    <tr>
+      <td><code>onClose</code></td>
+      <td><code>() =&gt; void</code></td>
+      <td>—</td>
+      <td>Called when the connection closes</td>
+    </tr>
+    <tr>
+      <td><code>onError</code></td>
+      <td><code>(event: Event) =&gt; void</code></td>
+      <td>—</td>
+      <td>Called when a WebSocket error occurs</td>
+    </tr>
+  </tbody>
+</table>
+
+### Methods
+
+<table>
+  <thead>
+    <tr>
+      <th>Method</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>connect(url?)</code></td>
+      <td>Open the WebSocket connection. Optionally override the URL.</td>
+    </tr>
+    <tr>
+      <td><code>send(data: string | Uint8Array)</code></td>
+      <td>Send data to the server. Strings are UTF-8 encoded. If the socket is not yet open, data is buffered and flushed on connect.</td>
+    </tr>
+    <tr>
+      <td><code>close()</code></td>
+      <td>Close the connection and stop reconnection attempts.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Properties
+
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>connected</code></td>
+      <td><code>boolean</code></td>
+      <td>Whether the WebSocket is currently open</td>
+    </tr>
+  </tbody>
+</table>
+
+### Example
+
+Connecting a terminal to a remote shell via WebSocket:
+
+```ts
+import { WTerm, WebSocketTransport } from "@wterm/dom";
+import "@wterm/dom/css";
+
+const term = new WTerm(document.getElementById("terminal"), {
+  cols: 80,
+  rows: 24,
+});
+await term.init();
+
+const ws = new WebSocketTransport({
+  url: "ws://localhost:8080/pty",
+  onData: (data) => term.write(data),
+  onOpen: () => console.log("connected"),
+  onClose: () => console.log("disconnected"),
+});
+
+ws.connect();
+term.onData = (data) => ws.send(data);
+```
+
+For a full working example with a Node.js PTY server, see the [Local Shell example](https://github.com/vercel-labs/wterm/tree/main/examples/local).

--- a/apps/docs/src/app/just-bash/layout.tsx
+++ b/apps/docs/src/app/just-bash/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("just-bash");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/docs/src/app/just-bash/page.mdx
+++ b/apps/docs/src/app/just-bash/page.mdx
@@ -1,0 +1,224 @@
+# Just Bash
+
+Shell adapter for wterm, powered by [just-bash](https://github.com/vercel-labs/just-bash). Provides line editing, tab completion, command history, and a colored prompt — all running in the browser with no backend.
+
+## Install
+
+```bash
+npm install @wterm/just-bash just-bash
+```
+
+`just-bash` is a peer dependency.
+
+## Quick Start
+
+```tsx
+import { useCallback, useRef } from "react";
+import { Terminal, useTerminal } from "@wterm/react";
+import { BashShell } from "@wterm/just-bash";
+import "@wterm/react/css";
+
+function App() {
+  const { ref, write } = useTerminal();
+  const shellRef = useRef<BashShell | null>(null);
+
+  const handleReady = useCallback(() => {
+    if (shellRef.current) return;
+    const shell = new BashShell({
+      files: { "/home/user/hello.txt": "Hello, world!\n" },
+      greeting: "Welcome to wterm!",
+    });
+    shellRef.current = shell;
+    shell.attach(write);
+  }, [write]);
+
+  const handleData = useCallback((data: string) => {
+    shellRef.current?.handleInput(data);
+  }, []);
+
+  return (
+    <Terminal
+      ref={ref}
+      onReady={handleReady}
+      onData={handleData}
+    />
+  );
+}
+```
+
+Use a ref to hold the `BashShell` instance so it's accessible from both the `onReady` and `onData` callbacks.
+
+## Options
+
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>files</code></td>
+      <td><code>Record&lt;string, string&gt;</code></td>
+      <td><code>&#123;&#125;</code></td>
+      <td>Virtual filesystem (keys are absolute paths, values are file contents)</td>
+    </tr>
+    <tr>
+      <td><code>env</code></td>
+      <td><code>Record&lt;string, string&gt;</code></td>
+      <td><code>&#123; SHELL, TERM &#125;</code></td>
+      <td>Environment variables</td>
+    </tr>
+    <tr>
+      <td><code>cwd</code></td>
+      <td><code>string</code></td>
+      <td><code>"/home/user"</code></td>
+      <td>Initial working directory</td>
+    </tr>
+    <tr>
+      <td><code>greeting</code></td>
+      <td><code>string | string[]</code></td>
+      <td>—</td>
+      <td>Lines printed when the shell attaches</td>
+    </tr>
+    <tr>
+      <td><code>prompt</code></td>
+      <td><code>(cwd: string) =&gt; string</code></td>
+      <td>colored <code>user@wterm:~$</code></td>
+      <td>Custom prompt function — receives the current working directory</td>
+    </tr>
+    <tr>
+      <td><code>network</code></td>
+      <td><code>NetworkConfig</code></td>
+      <td>—</td>
+      <td>Network access configuration (see <a href="#network-access">Network Access</a>)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Methods
+
+<table>
+  <thead>
+    <tr>
+      <th>Method</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>attach(write): Promise&lt;void&gt;</code></td>
+      <td>Connect to a terminal write function. Loads just-bash, prints the greeting, and displays the initial prompt.</td>
+    </tr>
+    <tr>
+      <td><code>handleInput(data): Promise&lt;void&gt;</code></td>
+      <td>Process terminal input (keystrokes, paste). Call this from the terminal's <code>onData</code> callback.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Properties
+
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>cwd</code></td>
+      <td><code>string</code></td>
+      <td>Current working directory (updates after <code>cd</code>)</td>
+    </tr>
+    <tr>
+      <td><code>bash</code></td>
+      <td><code>Bash | null</code></td>
+      <td>Underlying just-bash instance (<code>null</code> until <code>attach</code> completes)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Virtual Filesystem
+
+The `files` option populates an in-memory filesystem. Keys are absolute paths, values are file contents:
+
+```ts
+const shell = new BashShell({
+  files: {
+    "/home/user/README.md": "# My Project\n\nHello, world!\n",
+    "/home/user/src/main.zig": 'const std = @import("std");\n',
+    "/home/user/data/config.json": '{ "key": "value" }\n',
+  },
+});
+```
+
+Directories are created implicitly from file paths. Commands like `ls`, `cat`, `cd`, and `pwd` work against this virtual filesystem.
+
+## Network Access
+
+By default, the shell runs fully offline. To enable network access (for commands like `curl` or `fetch`), pass the `network` option from `just-bash`:
+
+```ts
+const shell = new BashShell({
+  network: {
+    dangerouslyAllowFullInternetAccess: true,
+  },
+});
+```
+
+The `NetworkConfig` type is re-exported from `just-bash`. See the [just-bash documentation](https://github.com/vercel-labs/just-bash) for all available network options.
+
+## Keyboard Shortcuts
+
+<table>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Tab</code></td>
+      <td>Autocomplete files and commands</td>
+    </tr>
+    <tr>
+      <td><code>Up</code> / <code>Down</code></td>
+      <td>Navigate command history</td>
+    </tr>
+    <tr>
+      <td><code>Left</code> / <code>Right</code></td>
+      <td>Move cursor within the current line</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl+A</code></td>
+      <td>Jump to start of line</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl+E</code></td>
+      <td>Jump to end of line</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl+U</code></td>
+      <td>Clear the current line</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl+C</code></td>
+      <td>Cancel current input</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl+L</code></td>
+      <td>Clear screen</td>
+    </tr>
+    <tr>
+      <td><code>&#92;</code> at end of line</td>
+      <td>Line continuation (multi-line input)</td>
+    </tr>
+  </tbody>
+</table>

--- a/apps/docs/src/app/markdown/layout.tsx
+++ b/apps/docs/src/app/markdown/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("markdown");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/docs/src/app/markdown/page.mdx
+++ b/apps/docs/src/app/markdown/page.mdx
@@ -1,0 +1,205 @@
+# Markdown
+
+Streaming Markdown-to-ANSI renderer for terminals. Designed for rendering LLM output in real time — push text chunks as they arrive and get styled terminal output back.
+
+## Install
+
+```bash
+npm install @wterm/markdown
+```
+
+## Quick Start
+
+### Vanilla JS
+
+```js
+import { WTerm } from "@wterm/dom";
+import { MarkdownRenderer } from "@wterm/markdown";
+import "@wterm/dom/css";
+
+const term = new WTerm(document.getElementById("terminal"));
+await term.init();
+
+const md = new MarkdownRenderer();
+const response = await fetch("/api/chat", { method: "POST" });
+const reader = response.body.getReader();
+const decoder = new TextDecoder();
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  const rendered = md.push(decoder.decode(value));
+  if (rendered) term.write(rendered);
+}
+
+term.write(md.flush());
+```
+
+### React
+
+```tsx
+import { useCallback, useRef } from "react";
+import { Terminal, useTerminal } from "@wterm/react";
+import { MarkdownRenderer } from "@wterm/markdown";
+import "@wterm/react/css";
+
+function App() {
+  const { ref, write } = useTerminal();
+  const mdRef = useRef(new MarkdownRenderer());
+
+  const handleReady = useCallback(async () => {
+    const response = await fetch("/api/chat", { method: "POST" });
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const rendered = mdRef.current.push(decoder.decode(value));
+      if (rendered) write(rendered);
+    }
+
+    write(mdRef.current.flush());
+  }, [write]);
+
+  return <Terminal ref={ref} onReady={handleReady} />;
+}
+```
+
+## Options
+
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>width</code></td>
+      <td><code>number</code></td>
+      <td><code>80</code></td>
+      <td>Terminal width in columns (used for horizontal rules)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Methods
+
+<table>
+  <thead>
+    <tr>
+      <th>Method</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>push(delta: string): string</code></td>
+      <td>Feed a chunk of Markdown text. Returns rendered ANSI output for any complete lines. Buffers incomplete lines internally.</td>
+    </tr>
+    <tr>
+      <td><code>flush(): string</code></td>
+      <td>Flush remaining buffered content. Call this when the stream ends to render any trailing text and close open code blocks.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Supported Syntax
+
+<table>
+  <thead>
+    <tr>
+      <th>Syntax</th>
+      <th>Rendering</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code># Heading</code> through <code>### Heading</code></td>
+      <td>Bold, bright white for h1–h2; bold for h3+</td>
+    </tr>
+    <tr>
+      <td><code>**bold**</code> or <code>__bold__</code></td>
+      <td>Bold text</td>
+    </tr>
+    <tr>
+      <td><code>*italic*</code> or <code>_italic_</code></td>
+      <td>Italic text</td>
+    </tr>
+    <tr>
+      <td><code>`code`</code></td>
+      <td>Cyan inline code</td>
+    </tr>
+    <tr>
+      <td><code>[text](url)</code></td>
+      <td>Underlined green link text with dimmed URL</td>
+    </tr>
+    <tr>
+      <td>Fenced code blocks (<code>```</code>)</td>
+      <td>Indented with dimmed borders</td>
+    </tr>
+    <tr>
+      <td><code>- item</code>, <code>* item</code>, <code>+ item</code></td>
+      <td>Unordered list with indented bullets</td>
+    </tr>
+    <tr>
+      <td><code>1. item</code> or <code>1) item</code></td>
+      <td>Ordered list with numbered items</td>
+    </tr>
+    <tr>
+      <td><code>&gt; quote</code></td>
+      <td>Blockquote with dimmed vertical bar</td>
+    </tr>
+    <tr>
+      <td><code>---</code>, <code>***</code>, <code>___</code></td>
+      <td>Dimmed horizontal rule</td>
+    </tr>
+  </tbody>
+</table>
+
+## Streaming LLM Output
+
+The renderer is designed for the streaming pattern common with LLM APIs. Here's a complete walkthrough:
+
+```ts
+import { MarkdownRenderer } from "@wterm/markdown";
+
+const md = new MarkdownRenderer();
+
+async function streamChat(
+  write: (data: string) => void,
+  prompt: string,
+) {
+  const response = await fetch("/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt }),
+  });
+
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    const chunk = decoder.decode(value, { stream: true });
+    const rendered = md.push(chunk);
+    if (rendered) write(rendered);
+  }
+
+  const remaining = md.flush();
+  if (remaining) write(remaining);
+}
+```
+
+**How it works:**
+
+1. Create a `MarkdownRenderer` instance before the stream starts
+2. As each chunk arrives, call `push(chunk)` — it buffers incomplete lines and only returns output for complete lines
+3. When the stream ends, call `flush()` to render any remaining buffered content and close open code blocks
+4. Write each non-empty result to the terminal with `write()`

--- a/apps/docs/src/lib/docs-navigation.ts
+++ b/apps/docs/src/lib/docs-navigation.ts
@@ -29,6 +29,14 @@ export const navGroups: NavGroup[] = [
     ],
   },
   {
+    label: "Packages",
+    items: [
+      { name: "Just Bash", href: "/just-bash" },
+      { name: "Markdown", href: "/markdown" },
+      { name: "Core / Advanced", href: "/core" },
+    ],
+  },
+  {
     label: "Examples",
     items: [
       {

--- a/apps/docs/src/lib/page-titles.ts
+++ b/apps/docs/src/lib/page-titles.ts
@@ -6,6 +6,9 @@ export const PAGE_TITLES: Record<string, string> = {
   themes: "Themes",
   react: "React",
   vanilla: "Vanilla JS",
+  "just-bash": "Just Bash",
+  markdown: "Markdown",
+  core: "Core / Advanced",
 };
 
 export function getPageTitle(slug: string): string | null {


### PR DESCRIPTION
## Summary

- **Just Bash** (`/just-bash`) — install, quick start with the ref pattern, options/methods/properties tables, virtual filesystem guide, network access docs, keyboard shortcuts
- **Markdown** (`/markdown`) — install, streaming examples for vanilla JS and React, options/methods tables, supported syntax reference, streaming LLM output walkthrough
- **Core / Advanced** (`/core`) — WasmBridge loading/methods/types with a headless example, WebSocketTransport options/methods/properties with a remote shell example
- Adds a new "Packages" nav group in the sidebar and registers page titles for all three routes