### PR TITLE
fix(security): strip ESC bytes from bracketed paste to prevent injection

### DIFF
--- a/packages/@wterm/dom/src/__tests__/input.test.ts
+++ b/packages/@wterm/dom/src/__tests__/input.test.ts
@@ -214,6 +214,22 @@ describe("InputHandler", () => {
       ta.dispatchEvent(pasteEvent);
       expect(received).toContain("\x1b[200~hello\x1b[201~");
     });
+
+    it("strips ESC bytes from bracketed paste to prevent injection", () => {
+      bridgeMock = { bracketedPaste: () => true } as any;
+      const ta = getTextarea();
+      const pasteEvent = new Event("paste", {
+        bubbles: true,
+        cancelable: true,
+      }) as any;
+      // Payload tries to escape bracketed paste mode and inject a command.
+      pasteEvent.clipboardData = {
+        getData: () => "safe\x1b[201~rm -rf /\r",
+      };
+      ta.dispatchEvent(pasteEvent);
+      expect(received.join("")).toBe("\x1b[200~safe[201~rm -rf /\r\x1b[201~");
+      expect(received.join("")).not.toContain("\x1b[201~rm");
+    });
   });
 
   describe("destroy", () => {

--- a/packages/@wterm/dom/src/input.ts
+++ b/packages/@wterm/dom/src/input.ts
@@ -177,7 +177,10 @@ export class InputHandler {
 
     const bridge = this.getBridge();
     if (bridge && bridge.bracketedPaste()) {
-      this.onData("\x1b[200~" + text + "\x1b[201~");
+      // Strip ESC bytes so clipboard payloads cannot inject \x1b[201~ to
+      // break out of bracketed paste mode and smuggle commands to the PTY.
+      const safe = text.replace(/\x1b/g, "");
+      this.onData("\x1b[200~" + safe + "\x1b[201~");
     } else {
       this.onData(text);
     }


### PR DESCRIPTION
## Security Vulnerability Report

**Type:** Bracketed paste mode escape sequence injection (sequence smuggling)
**Severity:** High
**Location:** `packages/@wterm/dom/src/input.ts:179-181`

### Description
When bracketed paste mode is active, `handlePaste` wraps clipboard content in `\x1b[200~ … \x1b[201~` markers and forwards it to the PTY/SSH stream. The clipboard text was forwarded **unmodified**, so a clipboard payload that itself contains the literal end marker `\x1b[201~` terminates bracketed paste mode early. Bytes after that marker are then treated by the receiving shell as ordinary keyboard input — including `\r` — which means clipboard content can execute arbitrary commands on the connected host.

This is the same class of issue tracked as *“sequence smuggling”* in xterm.js ([GHSA-h62m-39wp-xq3w](https://github.com/xtermjs/xterm.js/security/advisories/GHSA-h62m-39wp-xq3w)) and other terminal emulators. An attacker only needs to control clipboard contents (e.g. a malicious page calling `navigator.clipboard.writeText`, or a “copy this command” lure) to land arbitrary input in the user's shell when they paste into a wterm session backed by a real PTY/SSH stream like the bundled `examples/local` and `examples/ssh` apps.

#### Reproducer
```js
// On a malicious page (or any HTML the user trusts enough to focus + copy from):
navigator.clipboard.writeText('echo safe\x1b[201~rm -rf ~ #\r');
// User focuses wterm and pastes (Cmd/Ctrl-V).
// Pre-fix: PTY receives  \x1b[200~echo safe\x1b[201~rm -rf ~ #\r\x1b[201~
//   → bash leaves bracketed paste at the embedded \x1b[201~,
//     then runs `rm -rf ~` immediately because of the \r.
// Post-fix: ESC bytes are stripped, the embedded marker becomes inert text.
```

### Fix
Strip all `\x1b` bytes from pasted text in bracketed paste mode before wrapping it in the start/end markers. A literal escape character has no legitimate meaning inside a paste payload that the shell will treat as opaque text, so stripping is safe and matches the mitigation pattern adopted upstream by xterm.js and others. Non-bracketed-paste mode is unchanged: that path already exposes the user to traditional “paste auto-execute” because they (or their shell) opted out of the protection.

```diff
   if (bridge && bridge.bracketedPaste()) {
-    this.onData("\x1b[200~" + text + "\x1b[201~");
+    const safe = text.replace(/\x1b/g, "");
+    this.onData("\x1b[200~" + safe + "\x1b[201~");
   } else {
```

A regression test was added to `packages/@wterm/dom/src/__tests__/input.test.ts` that pastes `safe\x1b[201~rm -rf /\r` and asserts the embedded end-marker no longer escapes the bracketed paste envelope. All 27 tests in the package pass.

### Impact
Any deployment that connects wterm to a real shell (the bundled `examples/local` PTY app, the `examples/ssh` SSH client, or any consumer that wires `onData` to a server-side terminal) is exposed: a single paste from an attacker-controlled clipboard executes arbitrary commands as the connected shell user.

---
Found by [Aeon](https://github.com/aaronjmars/aeon-aaron) — automated security scanner