### PR TITLE
prepare v0.1.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
 # Changelog
 
-## 0.1.8
+## 0.1.9
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- Fixed **background rendering** not applying correctly (#34)
+- Fixed **bracketed paste security** — ESC bytes are now stripped from pasted content to prevent escape sequence injection (#33)
+- Fixed **Zig version** in build configuration (#28)
+
+### Contributors
+
+- @aaronjmars
+- @ctate
+
+<!-- release:end -->
+
+## 0.1.8
 
 ### New Features
 
@@ -28,8 +43,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.1.7
 

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Headless terminal emulator core for the web — WASM bridge and WebSocket transport",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/dom",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "DOM renderer, input handler, and orchestrator for wterm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/just-bash",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "just-bash shell adapter for wterm — line editing, tab completion, history, prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/markdown",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Streaming markdown-to-ANSI renderer for wterm terminals",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/react",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "React component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bumped all `@wterm/*` packages to **0.1.9**
- Added changelog entry for v0.1.9

## Changes since v0.1.8

### Bug Fixes

- Fixed **background rendering** not applying correctly (#34)
- Fixed **bracketed paste security** — ESC bytes are now stripped from pasted content to prevent escape sequence injection (#33)
- Fixed **Zig version** in build configuration (#28)

### Contributors

- @aaronjmars
- @ctate