### PR TITLE
exclude tests from tsc build output

### DIFF
--- a/packages/@wterm/core/tsconfig.json
+++ b/packages/@wterm/core/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }

--- a/packages/@wterm/dom/tsconfig.json
+++ b/packages/@wterm/dom/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }

--- a/packages/@wterm/just-bash/tsconfig.json
+++ b/packages/@wterm/just-bash/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }

--- a/packages/@wterm/markdown/tsconfig.json
+++ b/packages/@wterm/markdown/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }

--- a/packages/@wterm/react/tsconfig.json
+++ b/packages/@wterm/react/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }


### PR DESCRIPTION
## Summary

- Adds `"exclude": ["src/__tests__"]` to all 5 `@wterm/*` tsconfig files
- Test files were being compiled into `dist/__tests__/` and shipped in published tarballs — this stops that at the source