### PR TITLE
add trusted publisher release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Compare version to registry
+      - name: Compare versions to registry
         id: check
         run: |
           LOCAL_VERSION=$(node -p "require('./packages/@wterm/core/package.json').version")
-          NPM_VERSION=$(npm view "@wterm/core" version 2>/dev/null || echo "0.0.0")
-          echo "Local: $LOCAL_VERSION, Registry: $NPM_VERSION"
-
-          if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
-            SHOULD_RELEASE=true
-          else
-            SHOULD_RELEASE=false
-          fi
+          SHOULD_RELEASE=false
+          for pkg in core dom react just-bash markdown; do
+            REGISTRY_VERSION=$(npm view "@wterm/$pkg" version 2>/dev/null || echo "0.0.0")
+            echo "@wterm/$pkg — local: $LOCAL_VERSION, registry: $REGISTRY_VERSION"
+            if [ "$LOCAL_VERSION" != "$REGISTRY_VERSION" ]; then
+              SHOULD_RELEASE=true
+            fi
+          done
 
           echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
           echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,20 +26,17 @@ jobs:
         id: check
         run: |
           LOCAL_VERSION=$(node -p "require('./packages/@wterm/core/package.json').version")
-          echo "Local version: $LOCAL_VERSION"
+          NPM_VERSION=$(npm view "@wterm/core" version 2>/dev/null || echo "0.0.0")
+          echo "Local: $LOCAL_VERSION, Registry: $NPM_VERSION"
 
-          SHOULD_RELEASE=false
-          for pkg in core dom react just-bash markdown; do
-            NPM_VERSION=$(npm view "@wterm/$pkg" version 2>/dev/null || echo "0.0.0")
-            echo "@wterm/$pkg: registry=$NPM_VERSION local=$LOCAL_VERSION"
-            if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
-              SHOULD_RELEASE=true
-            fi
-          done
+          if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
+            SHOULD_RELEASE=true
+          else
+            SHOULD_RELEASE=false
+          fi
 
           echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
           echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Should release: $SHOULD_RELEASE"
 
   publish:
     name: Publish
@@ -72,14 +69,8 @@ jobs:
 
       - name: Publish packages
         run: |
-          LOCAL_VERSION=$(node -p "require('./packages/@wterm/core/package.json').version")
           for pkg in core dom react just-bash markdown; do
-            NPM_VERSION=$(npm view "@wterm/$pkg" version 2>/dev/null || echo "0.0.0")
-            if [ "$LOCAL_VERSION" = "$NPM_VERSION" ]; then
-              echo "@wterm/$pkg@$LOCAL_VERSION already published, skipping"
-              continue
-            fi
-            echo "Publishing @wterm/$pkg@$LOCAL_VERSION..."
+            echo "Publishing @wterm/$pkg..."
             (cd "packages/@wterm/$pkg" && npm publish --provenance)
           done
 
@@ -118,6 +109,7 @@ jobs:
             echo "Creating release $TAG..."
             gh release create "$TAG" \
               --title "$TAG" \
+              --target ${{ github.sha }} \
               --notes-file /tmp/release-notes.md
           fi
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,23 @@ jobs:
 
       - name: Publish packages
         run: |
+          LOCAL_VERSION="${{ needs.check-release.outputs.version }}"
+          FAILED=""
           for pkg in core dom react just-bash markdown; do
-            echo "Publishing @wterm/$pkg..."
-            (cd "packages/@wterm/$pkg" && npm publish --provenance)
+            REGISTRY_VERSION=$(npm view "@wterm/$pkg" version 2>/dev/null || echo "0.0.0")
+            if [ "$LOCAL_VERSION" = "$REGISTRY_VERSION" ]; then
+              echo "@wterm/$pkg@$LOCAL_VERSION already published, skipping"
+              continue
+            fi
+            echo "Publishing @wterm/$pkg@$LOCAL_VERSION..."
+            if ! (cd "packages/@wterm/$pkg" && npm publish --provenance); then
+              FAILED="$FAILED @wterm/$pkg"
+            fi
           done
+          if [ -n "$FAILED" ]; then
+            echo "Failed to publish:$FAILED"
+            exit 1
+          fi
 
   github-release:
     name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,17 +28,18 @@ jobs:
           LOCAL_VERSION=$(node -p "require('./packages/@wterm/core/package.json').version")
           echo "Local version: $LOCAL_VERSION"
 
-          NPM_VERSION=$(npm view @wterm/core version 2>/dev/null || echo "0.0.0")
-          echo "Registry version: $NPM_VERSION"
+          SHOULD_RELEASE=false
+          for pkg in core dom react just-bash markdown; do
+            NPM_VERSION=$(npm view "@wterm/$pkg" version 2>/dev/null || echo "0.0.0")
+            echo "@wterm/$pkg: registry=$NPM_VERSION local=$LOCAL_VERSION"
+            if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
+              SHOULD_RELEASE=true
+            fi
+          done
 
-          if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
-            echo "Version changed: $NPM_VERSION -> $LOCAL_VERSION"
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Version unchanged, skipping release"
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
           echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Should release: $SHOULD_RELEASE"
 
   publish:
     name: Publish
@@ -71,8 +72,14 @@ jobs:
 
       - name: Publish packages
         run: |
+          LOCAL_VERSION=$(node -p "require('./packages/@wterm/core/package.json').version")
           for pkg in core dom react just-bash markdown; do
-            echo "Publishing @wterm/$pkg..."
+            NPM_VERSION=$(npm view "@wterm/$pkg" version 2>/dev/null || echo "0.0.0")
+            if [ "$LOCAL_VERSION" = "$NPM_VERSION" ]; then
+              echo "@wterm/$pkg@$LOCAL_VERSION already published, skipping"
+              continue
+            fi
+            echo "Publishing @wterm/$pkg@$LOCAL_VERSION..."
             (cd "packages/@wterm/$pkg" && npm publish --provenance)
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  check-release:
+    name: Check for new version
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Compare version to registry
+        id: check
+        run: |
+          LOCAL_VERSION=$(node -p "require('./packages/@wterm/core/package.json').version")
+          echo "Local version: $LOCAL_VERSION"
+
+          NPM_VERSION=$(npm view @wterm/core version 2>/dev/null || echo "0.0.0")
+          echo "Registry version: $NPM_VERSION"
+
+          if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
+            echo "Version changed: $NPM_VERSION -> $LOCAL_VERSION"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version unchanged, skipping release"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish
+    needs: check-release
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    environment: Release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish packages
+        run: |
+          for pkg in core dom react just-bash markdown; do
+            echo "Publishing @wterm/$pkg..."
+            (cd "packages/@wterm/$pkg" && npm publish --provenance)
+          done
+
+  github-release:
+    name: Create GitHub Release
+    needs: [check-release, publish]
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract changelog entry
+        run: |
+          VERSION="${{ needs.check-release.outputs.version }}"
+
+          awk '/<!-- release:start -->/{found=1; next} /<!-- release:end -->/{found=0} found{print}' CHANGELOG.md > /tmp/release-notes.md
+
+          LINES=$(wc -l < /tmp/release-notes.md | tr -d ' ')
+          if [ "$LINES" -lt 2 ]; then
+            echo "Error: No release notes found between <!-- release:start --> and <!-- release:end --> markers in CHANGELOG.md"
+            exit 1
+          fi
+          echo "Extracted release notes for $VERSION ($LINES lines)"
+
+      - name: Create GitHub Release
+        run: |
+          VERSION="${{ needs.check-release.outputs.version }}"
+          TAG="v$VERSION"
+
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists, skipping"
+          else
+            echo "Creating release $TAG..."
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file /tmp/release-notes.md
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,4 @@ To prepare a release:
 5. Remove the `<!-- release:start -->` and `<!-- release:end -->` markers from the previous release entry (only the latest release should have markers)
 6. Open a PR and merge to `main`
 
-To publish (run locally after merging):
-
-```bash
-pnpm publish-packages
-```
-
-This builds all packages and publishes every `@wterm/*` package to npm.
+CI compares the version in `packages/@wterm/core/package.json` to what's on npm. If it differs, it builds, publishes all `@wterm/*` packages, and creates the GitHub release automatically. The release body is extracted from the content between the markers.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\" --ignore-path .gitignore",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx}\" --ignore-path .gitignore",
     "lint": "turbo run lint",
-    "publish-packages": "pnpm build && pnpm --filter './packages/@wterm/*' publish --no-git-checks",
     "sync-versions": "node scripts/sync-versions.mjs",
     "test": "turbo run test",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",


### PR DESCRIPTION
## Summary

- Adds a `release.yml` GitHub Actions workflow that uses npm trusted publishing (OIDC provenance) to publish all `@wterm/*` packages automatically
- Compares local `@wterm/core` version against the npm registry on each push to `main`; publishes with `--provenance` when the version changes
- Creates a GitHub Release with notes extracted from `CHANGELOG.md` release markers