### PR TITLE
fix(@wterm/vue): version sync, onData echo, debug prop, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ wterm ("dub-term") renders to the DOM — native text selection, copy/paste, fin
 | [`@wterm/core`](packages/@wterm/core) | Headless WASM bridge + WebSocket transport |
 | [`@wterm/dom`](packages/@wterm/dom) | DOM renderer, input handler — vanilla JS terminal |
 | [`@wterm/react`](packages/@wterm/react) | React component + `useTerminal` hook (TypeScript) |
+| [`@wterm/vue`](packages/@wterm/vue) | Vue 3 component + template ref API |
 | [`@wterm/just-bash`](packages/@wterm/just-bash) | In-browser Bash shell powered by just-bash |
 | [`@wterm/markdown`](packages/@wterm/markdown) | Render Markdown in the terminal |
 

--- a/packages/@wterm/core/README.md
+++ b/packages/@wterm/core/README.md
@@ -8,6 +8,7 @@ Headless terminal emulator core for [wterm](https://github.com/vercel-labs/wterm
 |---|---|
 | [`@wterm/dom`](https://www.npmjs.com/package/@wterm/dom) | DOM renderer, input handler — vanilla JS terminal |
 | [`@wterm/react`](https://www.npmjs.com/package/@wterm/react) | React component + `useTerminal` hook |
+| [`@wterm/vue`](https://www.npmjs.com/package/@wterm/vue) | Vue 3 component + template ref API |
 | [`@wterm/just-bash`](https://www.npmjs.com/package/@wterm/just-bash) | In-browser Bash shell powered by just-bash |
 | [`@wterm/markdown`](https://www.npmjs.com/package/@wterm/markdown) | Streaming Markdown-to-ANSI renderer for terminals |
 

--- a/packages/@wterm/vue/README.md
+++ b/packages/@wterm/vue/README.md
@@ -1,0 +1,119 @@
+# @wterm/vue
+
+Vue component for [wterm](https://github.com/vercel-labs/wterm) — a terminal emulator for the web.
+
+## Install
+
+```bash
+npm install @wterm/dom @wterm/vue
+```
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { Terminal } from "@wterm/vue";
+import "@wterm/vue/css";
+</script>
+
+<template>
+  <Terminal />
+</template>
+```
+
+By default, typed input is echoed back to the terminal. Listen to the `data` event when you need control over input:
+
+```vue
+<script setup lang="ts">
+import { useTemplateRef } from "vue";
+import { Terminal } from "@wterm/vue";
+import "@wterm/vue/css";
+
+const term = useTemplateRef("term");
+
+function onData(chunk: string) {
+  socket.send(chunk);
+}
+</script>
+
+<template>
+  <Terminal ref="term" @data="onData" />
+</template>
+```
+
+The WASM binary is embedded in the package — no extra setup required. To serve it separately instead, pass `wasmUrl`.
+
+## `<Terminal>` Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `cols` | `number` | `80` | Initial column count |
+| `rows` | `number` | `24` | Initial row count |
+| `wasmUrl` | `string` | — | Optional URL to serve the WASM binary separately (embedded by default) |
+| `theme` | `string` | — | Theme name (e.g. `"solarized-dark"`, `"monokai"`, `"light"`) |
+| `autoResize` | `boolean` | `false` | Auto-resize based on container dimensions |
+| `cursorBlink` | `boolean` | `false` | Enable cursor blinking animation |
+| `debug` | `boolean` | `false` | Enable debug mode. Exposes a `DebugAdapter` on the underlying `WTerm` instance for inspecting escape sequences, cell data, render performance, and unhandled CSI sequences. |
+
+Standard DOM attributes (`class`, `style`, `id`, ARIA props, etc.) are forwarded to the root `<div>` via `inheritAttrs`.
+
+## Events
+
+| Event | Payload | Description |
+|---|---|---|
+| `data` | `(data: string)` | Emitted when the terminal produces data (user input or host response). When no listener is attached, input is echoed back automatically. |
+| `title` | `(title: string)` | Emitted when the terminal title changes via an escape sequence. |
+| `resize` | `(cols: number, rows: number)` | Emitted after the terminal is resized. |
+| `ready` | `(wt: WTerm)` | Emitted once after `WTerm.init()` resolves, carrying the underlying `WTerm` instance. |
+| `error` | `(err: unknown)` | Emitted if WASM loading or initialization fails. |
+
+## Template Ref
+
+Access imperative methods via a template ref:
+
+```vue
+<script setup lang="ts">
+import { useTemplateRef } from "vue";
+import { Terminal, type WTerm } from "@wterm/vue";
+
+const term = useTemplateRef("term");
+
+function onReady(wt: WTerm) {
+  wt.write("hello\r\n");
+  term.value?.resize(120, 40);
+}
+</script>
+
+<template>
+  <Terminal ref="term" @ready="onReady" />
+</template>
+```
+
+| Member | Type | Description |
+|---|---|---|
+| `write` | `(data: string \| Uint8Array) => void` | Write data to the terminal |
+| `resize` | `(cols: number, rows: number) => void` | Resize the terminal |
+| `focus` | `() => void` | Focus the terminal |
+| `instance` | `WTerm \| null` | Underlying `WTerm` instance (`null` before mount) |
+
+## Themes
+
+Import the stylesheet to get the default theme and all built-in themes:
+
+```vue
+<script setup lang="ts">
+import "@wterm/vue/css";
+</script>
+```
+
+Switch themes via the `theme` prop:
+
+```vue
+<Terminal theme="monokai" />
+```
+
+Built-in: `solarized-dark`, `monokai`, `light`. Define custom themes with CSS custom properties.
+
+## License
+
+Apache-2.0

--- a/packages/@wterm/vue/package.json
+++ b/packages/@wterm/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/vue",
-  "version": "0.1.0",
+  "version": "0.1.9",
   "description": "Vue component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@internal/ts": "workspace:*",
     "@vue/test-utils": "^2.4.6",
-    "@wterm/dom": "^0.1.7",
+    "@wterm/dom": "workspace:*",
     "jsdom": "^29.0.2",
     "typescript": "^6.0.2",
     "vitest": "^2.1.9",

--- a/packages/@wterm/vue/src/Terminal.ts
+++ b/packages/@wterm/vue/src/Terminal.ts
@@ -1,5 +1,6 @@
 import {
   defineComponent,
+  getCurrentInstance,
   h,
   ref,
   shallowRef,
@@ -79,6 +80,12 @@ const Terminal = defineComponent({
      * @defaultValue false
      */
     cursorBlink: Boolean,
+    /**
+     * Enable debug mode (init-only — changing after mount has no effect).
+     * Exposes a `DebugAdapter` on the underlying `WTerm` instance.
+     * @defaultValue false
+     */
+    debug: Boolean,
   },
 
   // Object form: validator signatures carry emit payload types to
@@ -117,13 +124,18 @@ const Terminal = defineComponent({
       const el = root.value;
       if (!el) return;
 
+      const hasDataListener = !!getCurrentInstance()?.vnode.props?.onData;
+
       const wt = new WTerm(el, {
         cols: props.cols,
         rows: props.rows,
         wasmUrl: props.wasmUrl,
         autoResize: props.autoResize,
         cursorBlink: props.cursorBlink,
-        onData: (data: string) => emit("data", data),
+        debug: props.debug,
+        onData: hasDataListener
+          ? (data: string) => emit("data", data)
+          : undefined,
         onTitle: (title: string) => emit("title", title),
         onResize: (c: number, r: number) => emit("resize", c, r),
       });

--- a/packages/@wterm/vue/src/__tests__/Terminal.test.ts
+++ b/packages/@wterm/vue/src/__tests__/Terminal.test.ts
@@ -181,11 +181,35 @@ describe("Terminal component", () => {
   });
 
   it("emits data when WTerm onData fires", async () => {
-    const wrapper = await mountTerminal();
+    const onData = vi.fn();
+    const wrapper = await mountTerminal({}, { onData });
     await flushPromises();
     lastWTermInstance.onData("hello");
     expect(wrapper.emitted("data")).toBeTruthy();
     expect(wrapper.emitted("data")![0]).toEqual(["hello"]);
+  });
+
+  it("does not set onData on WTerm when no @data listener is provided", async () => {
+    await mountTerminal();
+    await flushPromises();
+    expect(lastWTermInstance.onData).toBeNull();
+  });
+
+  it("sets onData on WTerm when @data listener is provided", async () => {
+    const onData = vi.fn();
+    await mountTerminal({}, { onData });
+    await flushPromises();
+    expect(lastWTermInstance.onData).toBeTypeOf("function");
+  });
+
+  it("passes debug option to WTerm", async () => {
+    const { WTerm } = await import("@wterm/dom");
+    await mountTerminal({ debug: true });
+    await flushPromises();
+    expect(WTerm).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ debug: true }),
+    );
   });
 
   it("emits title when WTerm onTitle fires", async () => {

--- a/packages/@wterm/vue/src/__tests__/Terminal.types.test.ts
+++ b/packages/@wterm/vue/src/__tests__/Terminal.types.test.ts
@@ -49,6 +49,7 @@ describe("Terminal types", () => {
     expectTypeOf<Props["wasmUrl"]>().toEqualTypeOf<string | undefined>();
     expectTypeOf<Props["autoResize"]>().toEqualTypeOf<boolean | undefined>();
     expectTypeOf<Props["cursorBlink"]>().toEqualTypeOf<boolean | undefined>();
+    expectTypeOf<Props["debug"]>().toEqualTypeOf<boolean | undefined>();
   });
 
   it("typed emit signatures", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,8 +570,8 @@ importers:
         specifier: ^2.4.6
         version: 2.4.6
       '@wterm/dom':
-        specifier: ^0.1.7
-        version: 0.1.7
+        specifier: workspace:*
+        version: link:../dom
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@1.8.0)
@@ -3419,12 +3419,6 @@ packages:
         optional: true
       vue:
         optional: true
-
-  '@wterm/core@0.1.7':
-    resolution: {integrity: sha512-uP8R/OxO/cZUVOWD2q9SLgRTjqH6Ovd3se3SOJvwTi13yJazUF9hGlTrybLgNi4hmuGTHxHPSDSHvQrgf0KEeg==}
-
-  '@wterm/dom@0.1.7':
-    resolution: {integrity: sha512-235hVbza23+OIYuOror1y7L8MknISTg5yEobNqnNgUmUJ8GjCz5ertTZpZp6zE/1x4Ik2iBd8DjeG5J0g8MR+A==}
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -10095,12 +10089,6 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.2
       vue: 3.5.32(typescript@6.0.2)
-
-  '@wterm/core@0.1.7': {}
-
-  '@wterm/dom@0.1.7':
-    dependencies:
-      '@wterm/core': 0.1.7
 
   abbrev@2.0.0: {}
 


### PR DESCRIPTION
## Summary

- **Version sync**: bump `@wterm/vue` from `0.1.0` to `0.1.9` to match all other `@wterm/*` packages
- **Fix onData echo**: only wire `WTerm.onData` when a `@data` listener is attached, so basic `<Terminal />` usage echoes input automatically (matches `@wterm/react` behavior)
- **Add `debug` prop**: for parity with `@wterm/react`
- **Fix `@wterm/dom` devDep**: use `workspace:*` instead of pinned npm `^0.1.7`
- **Add package README**: `packages/@wterm/vue/README.md`
- **Add `@wterm/vue`** to root `README.md` and `@wterm/core/README.md` package tables