### PR TITLE
prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,25 @@
 # Changelog
 
-## 0.1.9
+## 0.2.0
 
 <!-- release:start -->
+
+### New Features
+
+- **Vue support** — added `@wterm/vue` package with `<Terminal />` component, `useTerminal` composable, auto-echo when `onData` is omitted, and `debug` prop (#30, #46)
+
+### Improvements
+
+- **Trusted publisher releases** — CI now uses trusted publisher workflow for npm publishing (#45)
+
+### Contributors
+
+- @ctate
+- @posva
+
+<!-- release:end -->
+
+## 0.1.9
 
 ### Bug Fixes
 
@@ -14,8 +31,6 @@
 
 - @aaronjmars
 - @ctate
-
-<!-- release:end -->
 
 ## 0.1.8
 

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/core",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Headless terminal emulator core for the web — WASM bridge and WebSocket transport",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/dom",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "DOM renderer, input handler, and orchestrator for wterm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/just-bash",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "just-bash shell adapter for wterm — line editing, tab completion, history, prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/markdown",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Streaming markdown-to-ANSI renderer for wterm terminals",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/react",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "React component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/vue/package.json
+++ b/packages/@wterm/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/vue",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Vue component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bump all `@wterm/*` packages to 0.2.0
- Add changelog entry for Vue support (`@wterm/vue`), trusted publisher releases, and contributor credits
- Remove release markers from the 0.1.9 entry

## Release notes

### New Features

- **Vue support** — added `@wterm/vue` package with `<Terminal />` component, `useTerminal` composable, auto-echo when `onData` is omitted, and `debug` prop (#30, #46)

### Improvements

- **Trusted publisher releases** — CI now uses trusted publisher workflow for npm publishing (#45)

### Contributors

- @ctate
- @posva