### PR TITLE
use node 24 for npm 11 trusted publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Summary

- Bumps the publish job from Node 20 (npm 10) to Node 24 (npm 11) so OIDC-based trusted publishing works — npm 10 can sign provenance but can't authenticate via OIDC