### PR TITLE
prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
-## 0.2.0
+## 0.2.1
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- Fixed **npm publish** — `workspace:*` peer dependencies are now resolved to real version ranges in published tarballs (#58)
+- Fixed **Vue package missing from releases** — `@wterm/vue` is now included in the release workflow (#58)
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.2.0
 
 ### New Features
 
@@ -16,8 +29,6 @@
 
 - @ctate
 - @posva
-
-<!-- release:end -->
 
 ## 0.1.9
 

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Headless terminal emulator core for the web — WASM bridge and WebSocket transport",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/dom",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DOM renderer, input handler, and orchestrator for wterm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/just-bash",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "just-bash shell adapter for wterm — line editing, tab completion, history, prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/markdown",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Streaming markdown-to-ANSI renderer for wterm terminals",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/vue/package.json
+++ b/packages/@wterm/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/vue",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Vue component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bump all `@wterm/*` packages to 0.2.1
- Add changelog entry for the `workspace:*` publish fix and Vue release inclusion (#58)