### PR TITLE
Fix GhosttyCore scrollback cells rendering with black colors

### DIFF
--- a/packages/@wterm/ghostty/src/ghostty-core.ts
+++ b/packages/@wterm/ghostty/src/ghostty-core.ts
@@ -257,14 +257,17 @@ export class GhosttyCore implements TerminalCore {
     const cell = parseCell(view, col * CELL_BYTES);
     freeBuffer(this.wasm, bufPtr, lineSize);
 
-    return {
+    const result: CellData = {
       char: cell.codepoint || 32,
       fg: DEFAULT_COLOR,
       bg: DEFAULT_COLOR,
       flags: cell.flags,
-      fgRgb: packRgb(cell.fgR, cell.fgG, cell.fgB),
-      bgRgb: packRgb(cell.bgR, cell.bgG, cell.bgB),
     };
+    if (cell.colorFlags & 1)
+      result.fgRgb = packRgb(cell.fgR, cell.fgG, cell.fgB);
+    if (cell.colorFlags & 2)
+      result.bgRgb = packRgb(cell.bgR, cell.bgG, cell.bgB);
+    return result;
   }
 
   getScrollbackLineLen(offset: number): number {


### PR DESCRIPTION
## Summary
- Fix `getScrollbackCell()` in `@wterm/ghostty` unconditionally packing RGB values into `fgRgb`/`bgRgb` even when `colorFlags` indicates no explicit color was set
- This caused scrollback lines to always render with `rgb(0,0,0)` (black) foreground/background instead of using terminal default colors
- Now matches the same `colorFlags` check pattern used by `getCell()`

## Before
```ts
return {
  char: cell.codepoint || 32,
  fg: DEFAULT_COLOR, bg: DEFAULT_COLOR,
  flags: cell.flags,
  fgRgb: packRgb(cell.fgR, cell.fgG, cell.fgB), // always set → black
  bgRgb: packRgb(cell.bgR, cell.bgG, cell.bgB), // always set → black
};
```

## After
```ts
const result = { char: cell.codepoint || 32, fg: DEFAULT_COLOR, bg: DEFAULT_COLOR, flags: cell.flags };
if (cell.colorFlags & 1) result.fgRgb = packRgb(...);
if (cell.colorFlags & 2) result.bgRgb = packRgb(...);
return result;
```

## Test plan
- [ ] Verify scrollback lines in Ghostty core render with correct colors instead of black
- [ ] Compare scrollback rendering with viewport rendering — colors should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)