### PR TITLE
Fix WebSocket reconnect delay not resetting on new connect()

### DIFF
--- a/packages/@wterm/core/src/transport.ts
+++ b/packages/@wterm/core/src/transport.ts
@@ -38,6 +38,7 @@ export class WebSocketTransport {
     if (!this.url) throw new Error("No WebSocket URL provided");
 
     this._closed = false;
+    this._reconnectDelay = 1000;
     this._ws = new WebSocket(this.url);
     this._ws.binaryType = "arraybuffer";
 


### PR DESCRIPTION
## Summary
- Fix `WebSocketTransport.connect()` not resetting `_reconnectDelay` when starting a new connection
- If a previous session had exponentially backed off to the max delay (e.g., 30s), calling `connect()` again would inherit that stale delay instead of starting fresh
- `_reconnectDelay` is now reset to `1000` at the start of `connect()`, consistent with the reset that happens on `onopen`

## How to reproduce
1. Connect to a WebSocket server
2. Let the connection drop and reconnect multiple times until backoff reaches 30s
3. Close the connection manually
4. Call `connect()` again — without this fix, the first reconnect attempt waits 30s instead of 1s

## Test plan
- [ ] Test connect → disconnect → reconnect cycle and verify initial delay is always 1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)