### PR TITLE
Fix writeRaw buffer view invalidation on WASM memory growth

### DIFF
--- a/packages/@wterm/core/src/wasm-bridge.ts
+++ b/packages/@wterm/core/src/wasm-bridge.ts
@@ -102,10 +102,10 @@ export class WasmBridge implements TerminalCore {
   }
 
   writeRaw(data: Uint8Array): void {
-    const buf = new Uint8Array(this.memory.buffer, this.writeBufferPtr, 8192);
     let offset = 0;
     while (offset < data.length) {
       const chunk = Math.min(data.length - offset, 8192);
+      const buf = new Uint8Array(this.memory.buffer, this.writeBufferPtr, 8192);
       buf.set(data.subarray(offset, offset + chunk));
       this.exports.writeBytes(chunk);
       offset += chunk;


### PR DESCRIPTION
## Summary
- Fix `writeRaw()` in `WasmBridge` creating a single `Uint8Array` view before the write loop
- If `writeBytes()` triggers WASM memory growth (buffer detaches), subsequent iterations of the loop would fail because the view references a detached `ArrayBuffer`
- Create a fresh `Uint8Array` view in each loop iteration to handle potential memory growth

## Root cause
`WebAssembly.Memory.grow()` detaches the old `ArrayBuffer`. The write loop reuses the same `buf` view across iterations, but `writeBytes()` can trigger memory growth internally.

## Test plan
- [ ] Run existing unit tests: `pnpm test`
- [ ] Test writing large amounts of data that exceed the initial WASM memory size

🤖 Generated with [Claude Code](https://claude.com/claude-code)