### PR TITLE
Fix escapeHTML missing double quote escaping

### DIFF
--- a/packages/@wterm/dom/src/renderer.ts
+++ b/packages/@wterm/dom/src/renderer.ts
@@ -93,7 +93,8 @@ function escapeHTML(text: string): string {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 function resolveColors(


### PR DESCRIPTION
## Summary
- Fix `escapeHTML()` in `@wterm/dom` renderer not escaping double quotes (`"`)
- The function is used to sanitize text before injecting into `innerHTML` via `<span style="${runStyle}">` — unescaped `"` could theoretically break out of the style attribute
- Add `&quot;` replacement for defense in depth

## Test plan
- [ ] Run existing renderer tests: `pnpm test`
- [ ] Verify terminal rendering still works correctly with normal content

🤖 Generated with [Claude Code](https://claude.com/claude-code)