### PR TITLE
fix: prevent hidden textarea focus from scrolling page

### DIFF
--- a/packages/@wterm/dom/src/input.ts
+++ b/packages/@wterm/dom/src/input.ts
@@ -74,8 +74,10 @@ export class InputHandler {
     this.textarea.setAttribute("tabindex", "0");
     this.textarea.setAttribute("aria-hidden", "true");
     const s = this.textarea.style;
-    s.position = "absolute";
-    s.left = "-9999px";
+    // Keep the focus target in the viewport so mobile/Chromium browsers do not
+    // try to scroll the page to reveal an off-screen textarea while typing.
+    s.position = "fixed";
+    s.left = "0";
     s.top = "0";
     s.width = "1px";
     s.height = "1px";
@@ -145,7 +147,7 @@ export class InputHandler {
       if (sel && sel.toString().length > 0) return;
     }
     if ((e.metaKey || e.ctrlKey) && e.key === "v") {
-      this.textarea.focus();
+      this.textarea.focus({ preventScroll: true });
       return;
     }
     if (e.metaKey && !e.ctrlKey) {


### PR DESCRIPTION
## Summary
- keep the hidden textarea focus target fixed within the viewport instead of positioning it far off-screen
- use `focus({ preventScroll: true })` for the paste shortcut refocus path

This prevents browsers from scrolling the page toward the hidden input while typing or pasting.

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @wterm/core build`
- `corepack pnpm --filter @wterm/dom type-check`
- `corepack pnpm --filter @wterm/dom test`

DOM package tests: 68 passed.