### PR TITLE
fix(dom): avoid leaking cell background to container

### DIFF
--- a/packages/@wterm/dom/src/__tests__/renderer.test.ts
+++ b/packages/@wterm/dom/src/__tests__/renderer.test.ts
@@ -121,5 +121,20 @@ describe("Renderer", () => {
       const span = container.querySelector("span[style]");
       expect(span?.getAttribute("style")).toMatch(/font-weight:\s*bold/);
     });
+
+    it("does not leak the bottom-right cell background to the container", () => {
+      const grid = [
+        [makeCell("A", 256, 256), makeCell("B", 256, 2)],
+      ];
+      const bridge = createMockBridge(2, 1, grid);
+      const renderer = new Renderer(container);
+
+      renderer.render(bridge as any);
+
+      expect(container.style.background).toBe("");
+      expect(container.querySelector(".term-row")?.getAttribute("style")).toContain(
+        "background",
+      );
+    });
   });
 });

--- a/packages/@wterm/dom/src/renderer.ts
+++ b/packages/@wterm/dom/src/renderer.ts
@@ -205,7 +205,6 @@ export class Renderer {
   private rowEls: HTMLDivElement[] = [];
   private prevCursorRow = -1;
   private prevCursorCol = -1;
-  private prevContainerBg = "";
   private prevRowBg: string[] = [];
 
   private _scrollbackRowEls: HTMLDivElement[] = [];
@@ -437,24 +436,6 @@ export class Renderer {
 
     this.prevCursorRow = cursor.row;
     this.prevCursorCol = cursor.col;
-
-    const lastRowDirty = resized || core.isDirtyRow(this.rows - 1);
-    if (lastRowDirty) {
-      const bottomRight = core.getCell(this.rows - 1, this.cols - 1);
-      let gridBgIdx = bottomRight.bg;
-      let gridBgRgb = bottomRight.bgRgb;
-      if (bottomRight.flags & FLAG_REVERSE) {
-        gridBgIdx = bottomRight.fg;
-        gridBgRgb = bottomRight.fgRgb;
-        if (gridBgRgb === undefined && gridBgIdx === DEFAULT_COLOR)
-          gridBgIdx = 7;
-      }
-      const containerBg = cellBgCSS(gridBgIdx, gridBgRgb) || "";
-      if (containerBg !== this.prevContainerBg) {
-        this.container.style.background = containerBg;
-        this.prevContainerBg = containerBg;
-      }
-    }
 
     core.clearDirty();
   }

--- a/packages/@wterm/dom/src/terminal.css
+++ b/packages/@wterm/dom/src/terminal.css
@@ -46,6 +46,8 @@
 .term-grid {
   display: block;
   white-space: pre;
+  min-height: 100%;
+  background: var(--term-bg);
   contain: layout paint style;
   will-change: contents;
 }


### PR DESCRIPTION
## Summary
- stop mirroring the bottom-right cell background onto the terminal container
- keep per-cell and full-row backgrounds rendered normally
- add a regression test for tmux/status-line-style bottom-right backgrounds

## Why
Full-width UI elements such as tmux status bars can color the bottom-right cell. Mirroring that cell onto the container makes the status bar background leak into the entire terminal.

## Test
- `corepack pnpm --filter @wterm/dom test`
- `corepack pnpm --filter @wterm/dom type-check`
