### PR TITLE
fix(@wterm/core): revalidate WASM views after memory growth

### DIFF
--- a/packages/@wterm/core/src/__tests__/wasm-memory-growth.test.ts
+++ b/packages/@wterm/core/src/__tests__/wasm-memory-growth.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { WasmBridge } from "../wasm-bridge.js";
+
+describe("WasmBridge memory growth", () => {
+  let bridge: WasmBridge;
+
+  beforeEach(async () => {
+    bridge = await WasmBridge.load();
+    bridge.init(80, 24);
+  });
+
+  describe("writeRaw", () => {
+    it("survives WASM memory growth mid-write", () => {
+      const mem: WebAssembly.Memory = (bridge as any).memory;
+      const originalExports = (bridge as any).exports;
+      const originalWriteBytes =
+        originalExports.writeBytes.bind(originalExports);
+
+      // Simulate the WASM module growing its own memory in response to a
+      // write (e.g. to fit a bigger ring buffer / scrollback). This detaches
+      // any ArrayBuffer view created before the growth. WASM export
+      // properties are non-configurable, so swap in a plain object copy
+      // instead of mutating the original in place.
+      const wrapped: Record<string, unknown> = {};
+      for (const key of Object.keys(originalExports)) {
+        wrapped[key] = (originalExports as Record<string, unknown>)[key];
+      }
+      wrapped.writeBytes = (len: number) => {
+        originalWriteBytes(len);
+        mem.grow(1);
+      };
+      (bridge as any).exports = wrapped;
+
+      // Force multiple loop iterations inside writeRaw (chunk size is 8192).
+      const data = new Uint8Array(20000).fill("X".charCodeAt(0));
+
+      expect(() => bridge.writeRaw(data)).not.toThrow();
+      expect(bridge.getCell(0, 0).char).toBe(88); // 'X'
+    });
+  });
+
+  describe("getCell", () => {
+    it("survives WASM memory growth after the view was cached", () => {
+      bridge.writeString("A");
+      const mem: WebAssembly.Memory = (bridge as any).memory;
+
+      // Grow memory independently of resize/init, which is what leaves a
+      // cached DataView pointing at a detached ArrayBuffer.
+      mem.grow(1);
+
+      expect(() => bridge.getCell(0, 0)).not.toThrow();
+      expect(bridge.getCell(0, 0).char).toBe(65); // 'A'
+    });
+  });
+
+  describe("getScrollbackCell", () => {
+    it("survives WASM memory growth after the view was cached", () => {
+      for (let i = 0; i < 30; i++) {
+        bridge.writeString("A\r\n");
+      }
+      const count = bridge.getScrollbackCount();
+      expect(count).toBeGreaterThan(0);
+
+      const mem: WebAssembly.Memory = (bridge as any).memory;
+      mem.grow(1);
+
+      expect(() => bridge.getScrollbackCell(0, 0)).not.toThrow();
+      expect(bridge.getScrollbackCell(0, 0).char).toBe(65); // 'A'
+    });
+  });
+});

--- a/packages/@wterm/core/src/wasm-bridge.ts
+++ b/packages/@wterm/core/src/wasm-bridge.ts
@@ -59,6 +59,15 @@ export class WasmBridge implements TerminalCore {
   private encoder = new TextEncoder();
   private decoder = new TextDecoder();
   private _dv!: DataView;
+  private _dvBuffer: ArrayBuffer | null = null;
+
+  private get dv(): DataView {
+    if (this._dvBuffer !== this.memory.buffer) {
+      this._dvBuffer = this.memory.buffer;
+      this._dv = new DataView(this.memory.buffer);
+    }
+    return this._dv;
+  }
 
   constructor(instance: WebAssembly.Instance) {
     this.exports = instance.exports as unknown as WasmExports;
@@ -93,7 +102,6 @@ export class WasmBridge implements TerminalCore {
     this.writeBufferPtr = this.exports.getWriteBuffer();
     this.cellSize = this.exports.getCellSize();
     this.maxCols = this.exports.getMaxCols();
-    this._dv = new DataView(this.memory.buffer);
   }
 
   writeString(str: string): void {
@@ -102,10 +110,10 @@ export class WasmBridge implements TerminalCore {
   }
 
   writeRaw(data: Uint8Array): void {
-    const buf = new Uint8Array(this.memory.buffer, this.writeBufferPtr, 8192);
     let offset = 0;
     while (offset < data.length) {
       const chunk = Math.min(data.length - offset, 8192);
+      const buf = new Uint8Array(this.memory.buffer, this.writeBufferPtr, 8192);
       buf.set(data.subarray(offset, offset + chunk));
       this.exports.writeBytes(chunk);
       offset += chunk;
@@ -114,7 +122,7 @@ export class WasmBridge implements TerminalCore {
 
   getCell(row: number, col: number): CellData {
     const offset = this.gridPtr + (row * this.maxCols + col) * this.cellSize;
-    const dv = this._dv;
+    const dv = this.dv;
     return {
       char: dv.getUint32(offset, true),
       fg: dv.getUint16(offset + 4, true),
@@ -181,7 +189,7 @@ export class WasmBridge implements TerminalCore {
   getScrollbackCell(offset: number, col: number): CellData {
     const ptr = this.exports.getScrollbackLine(offset);
     const off = ptr + col * this.cellSize;
-    const dv = this._dv;
+    const dv = this.dv;
     return {
       char: dv.getUint32(off, true),
       fg: dv.getUint16(off + 4, true),


### PR DESCRIPTION
Cached views over WASM memory detach when the module grows memory mid-call, throwing `Cannot perform ... on a detached ArrayBuffer`.

Two call paths were affected:

- `writeRaw()` built one `Uint8Array` before the loop, but `writeBytes()` inside the loop can grow memory. The view is now created per chunk, so only writes over 8192 bytes were at risk.
- `getCell()` and `getScrollbackCell()` read through a `DataView` cached once at init. It is now invalidated by buffer identity rather than rebuilt per call, since `getCell()` runs per cell per frame.

Tests run against the real compiled WASM module and fail on `main` with the detached buffer error.

Supersedes #65 and #68 by @hobostay.
