### PR TITLE
fix(@wterm/ghostty): respect colorFlags in getScrollbackCell

### DIFF
--- a/packages/@wterm/ghostty/package.json
+++ b/packages/@wterm/ghostty/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "pnpm build",
+    "test": "vitest run",
     "type-check": "tsc --noEmit",
     "rebuild-wasm": "bash scripts/build-wasm.sh"
   },

--- a/packages/@wterm/ghostty/src/__tests__/ghostty-core.test.ts
+++ b/packages/@wterm/ghostty/src/__tests__/ghostty-core.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * getScrollbackCell() reads a single scrollback cell out of a WASM-owned
+ * buffer written by get_scrollback_line(). We fake that buffer here so we
+ * can exercise GhosttyCore's parsing logic without needing a real
+ * ghostty-vt.wasm build (which loadGhosttyWasm() fetches over the network).
+ */
+const state = vi.hoisted(() => {
+  return {
+    memory: new WebAssembly.Memory({ initial: 1 }),
+    line: null as Uint8Array | null,
+    lineLen: 0,
+  };
+});
+
+vi.mock("../wasm-bindings.js", async () => {
+  const actual = await vi.importActual<typeof import("../wasm-bindings.js")>(
+    "../wasm-bindings.js",
+  );
+
+  const exports = {
+    memory: state.memory,
+    init: () => 1,
+    resize: () => {},
+    // 0 is treated as an allocation failure by ghostty-core.ts, so the
+    // fake pointer must be nonzero.
+    alloc_buffer: () => 64,
+    free_buffer: () => {},
+    get_scrollback_line: (
+      _ptr: number,
+      _offset: number,
+      bufPtr: number,
+      _maxCols: number,
+    ) => {
+      if (!state.line) return 0;
+      new Uint8Array(state.memory.buffer, bufPtr, state.line.length).set(
+        state.line,
+      );
+      return state.lineLen;
+    },
+  };
+
+  return {
+    ...actual,
+    loadGhosttyWasm: vi.fn(async () => ({
+      exports,
+      instance: {} as WebAssembly.Instance,
+    })),
+  };
+});
+
+const { GhosttyCore } = await import("../ghostty-core.js");
+const { CELL_BYTES } = await import("../wasm-bindings.js");
+
+/** Build one raw scrollback cell matching the 16-byte wasm_api.zig layout. */
+function buildCellBytes(opts: {
+  codepoint: number;
+  fgR?: number;
+  fgG?: number;
+  fgB?: number;
+  bgR?: number;
+  bgG?: number;
+  bgB?: number;
+  flags?: number;
+  colorFlags: number;
+}): Uint8Array {
+  const buf = new ArrayBuffer(CELL_BYTES);
+  const view = new DataView(buf);
+  view.setUint32(0, opts.codepoint, true);
+  view.setUint8(4, opts.fgR ?? 0);
+  view.setUint8(5, opts.fgG ?? 0);
+  view.setUint8(6, opts.fgB ?? 0);
+  view.setUint8(7, opts.bgR ?? 0);
+  view.setUint8(8, opts.bgG ?? 0);
+  view.setUint8(9, opts.bgB ?? 0);
+  view.setUint8(10, opts.flags ?? 0);
+  view.setUint8(11, 1); // width
+  view.setUint8(12, opts.colorFlags);
+  return new Uint8Array(buf);
+}
+
+describe("GhosttyCore.getScrollbackCell", () => {
+  beforeEach(() => {
+    state.line = null;
+    state.lineLen = 0;
+  });
+
+  it("does not set fgRgb/bgRgb when colorFlags === 0 (falls back to defaults)", async () => {
+    state.line = buildCellBytes({ codepoint: 65, colorFlags: 0 });
+    state.lineLen = 1;
+
+    const core = await GhosttyCore.load();
+    core.init(80, 24);
+    const cell = core.getScrollbackCell(0, 0);
+
+    expect(cell.char).toBe(65);
+    expect(cell.fgRgb).toBeUndefined();
+    expect(cell.bgRgb).toBeUndefined();
+  });
+
+  it("sets fgRgb/bgRgb from the explicit color bytes when colorFlags is set", async () => {
+    state.line = buildCellBytes({
+      codepoint: 66,
+      fgR: 10,
+      fgG: 20,
+      fgB: 30,
+      bgR: 40,
+      bgG: 50,
+      bgB: 60,
+      colorFlags: 0b11,
+    });
+    state.lineLen = 1;
+
+    const core = await GhosttyCore.load();
+    core.init(80, 24);
+    const cell = core.getScrollbackCell(0, 0);
+
+    expect(cell.char).toBe(66);
+    expect(cell.fgRgb).toBe((10 << 16) | (20 << 8) | 30);
+    expect(cell.bgRgb).toBe((40 << 16) | (50 << 8) | 60);
+  });
+});

--- a/packages/@wterm/ghostty/src/ghostty-core.ts
+++ b/packages/@wterm/ghostty/src/ghostty-core.ts
@@ -257,14 +257,17 @@ export class GhosttyCore implements TerminalCore {
     const cell = parseCell(view, col * CELL_BYTES);
     freeBuffer(this.wasm, bufPtr, lineSize);
 
-    return {
+    const result: CellData = {
       char: cell.codepoint || 32,
       fg: DEFAULT_COLOR,
       bg: DEFAULT_COLOR,
       flags: cell.flags,
-      fgRgb: packRgb(cell.fgR, cell.fgG, cell.fgB),
-      bgRgb: packRgb(cell.bgR, cell.bgG, cell.bgB),
     };
+    if (cell.colorFlags & 1)
+      result.fgRgb = packRgb(cell.fgR, cell.fgG, cell.fgB);
+    if (cell.colorFlags & 2)
+      result.bgRgb = packRgb(cell.bgR, cell.bgG, cell.bgB);
+    return result;
   }
 
   getScrollbackLineLen(offset: number): number {

--- a/packages/@wterm/ghostty/vitest.config.ts
+++ b/packages/@wterm/ghostty/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/__tests__/**"],
+    },
+  },
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -4,6 +4,7 @@ export default defineWorkspace([
   "packages/@wterm/markdown",
   "packages/@wterm/core",
   "packages/@wterm/dom",
+  "packages/@wterm/ghostty",
   "packages/@wterm/react",
   "packages/@wterm/just-bash",
 ]);


### PR DESCRIPTION
`getScrollbackCell()` packed `fgRgb`/`bgRgb` unconditionally. Since `packRgb(0,0,0)` is a valid value, every scrollback cell without an explicit color rendered black instead of falling back to the terminal default, so scrollback came out black on black.

The fix mirrors the `colorFlags` check `getCell()` already uses in the same file.

`@wterm/ghostty` had no test setup, so `turbo run test` skipped the package entirely. This adds the same vitest wiring the other packages use, which is what makes the regression test actually run in CI.

<img width="1324" height="439" alt="image" src="https://github.com/user-attachments/assets/0d5edcfc-995a-4872-8587-60f37c3cad7f" />


Supersedes #66 by @hobostay.
