### PR TITLE
fix(@wterm/dom): escape double quotes in escapeHTML

### DIFF
--- a/packages/@wterm/dom/src/__tests__/renderer.test.ts
+++ b/packages/@wterm/dom/src/__tests__/renderer.test.ts
@@ -121,5 +121,35 @@ describe("Renderer", () => {
       const span = container.querySelector("span[style]");
       expect(span?.getAttribute("style")).toMatch(/font-weight:\s*bold/);
     });
+
+    it("escapes double quotes before assigning to innerHTML", () => {
+      const grid = [[makeCell('"')]];
+      const bridge = createMockBridge(1, 1, grid);
+      const renderer = new Renderer(container);
+
+      let proto = Object.getPrototypeOf(container);
+      while (proto && !Object.getOwnPropertyDescriptor(proto, "innerHTML")) {
+        proto = Object.getPrototypeOf(proto);
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(proto, "innerHTML")!;
+      const assignedValues: string[] = [];
+      Object.defineProperty(proto, "innerHTML", {
+        ...descriptor,
+        set(value: string) {
+          assignedValues.push(value);
+          descriptor.set!.call(this, value);
+        },
+      });
+
+      try {
+        renderer.render(bridge as any);
+      } finally {
+        Object.defineProperty(proto, "innerHTML", descriptor);
+      }
+
+      const rowHtml = assignedValues.find((v) => v.includes('">'));
+      expect(rowHtml).toContain("&quot;");
+      expect(container.querySelector(".term-row")?.textContent).toBe('"');
+    });
   });
 });

--- a/packages/@wterm/dom/src/renderer.ts
+++ b/packages/@wterm/dom/src/renderer.ts
@@ -93,7 +93,8 @@ function escapeHTML(text: string): string {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 function resolveColors(


### PR DESCRIPTION
`escapeHTML()` escaped `&`, `<` and `>` but not `"`.

This is not closing an active vulnerability. All seven call sites place the output in text node position, never inside an attribute value, and in text position `&quot;` renders identically to `"`. The change makes the helper correct for any future attribute usage.

Supersedes #69 by @hobostay.
