### PR TITLE
chore: prepare v0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
-## 0.3.0
+## 0.3.1
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- **WASM view invalidation** — cached `DataView` and `Uint8Array` views over WASM memory became detached when the module grew memory mid-call, throwing on `getCell`, `getScrollbackCell` and multi-chunk `writeRaw` (#92)
+- **Scrollback colors in `@wterm/ghostty`** — `getScrollbackCell()` packed `fgRgb`/`bgRgb` regardless of `colorFlags`, so cells with no explicit color rendered black instead of the terminal default (#93)
+- **`escapeHTML` double quotes** — the DOM renderer's escape helper left `"` unescaped (#94)
+
+### Improvements
+
+- **Test coverage for `@wterm/ghostty`** — the package had no test setup, so `turbo run test` skipped it entirely. It now runs in CI like the other packages (#93)
+
+### Contributors
+
+- @hobostay
+
+<!-- release:end -->
+
+## 0.3.0
 
 ### New Features
 
@@ -21,8 +39,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Contributors
 
 - @hobostay
+- @Railly
 
 <!-- release:end -->
 

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Headless terminal emulator core for the web — WASM bridge and WebSocket transport",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/dom",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "DOM renderer, input handler, and orchestrator for wterm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/ghostty/package.json
+++ b/packages/@wterm/ghostty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/ghostty",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "libghostty-powered terminal core for wterm — full-featured VT emulation via Ghostty's WASM build",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/just-bash",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "just-bash shell adapter for wterm — line editing, tab completion, history, prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/markdown",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Streaming markdown-to-ANSI renderer for wterm terminals",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/react",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/vue/package.json
+++ b/packages/@wterm/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/vue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Vue component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump to 0.3.1 across all seven packages via `scripts/sync-versions.mjs`, plus the changelog entry with the release markers moved onto the new section.

Merging this is the release: it makes `should_release` true, publishes to npm, and creates the `v0.3.1` tag.

Covers #92, #93 and #94.
