### PR TITLE
fix(@wterm/ghostty): name the cause when the default WASM URL is unusable

### DIFF
--- a/apps/docs/src/app/ghostty/page.mdx
+++ b/apps/docs/src/app/ghostty/page.mdx
@@ -83,6 +83,55 @@ const core = await GhosttyCore.load();
   </tbody>
 </table>
 
+## Bundlers
+
+The WASM binary is fetched at runtime rather than inlined, so the default has to resolve to a URL your app serves. `GhosttyCore.load()` resolves it with `new URL("../wasm/ghostty-vt.wasm", import.meta.url)`. Bundlers that implement that asset pattern emit the binary and rewrite the URL. Ones that do not leave `import.meta.url` pointing at the machine that built the bundle, and `load()` throws an error saying so.
+
+<table>
+  <thead>
+    <tr>
+      <th>Bundler</th>
+      <th>
+        Default <code>GhosttyCore.load()</code>
+      </th>
+      <th>Verified</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Vite (dev and build)</td>
+      <td>Works, emits a hashed asset.</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Bun dev server</td>
+      <td>
+        Fails, pass <code>wasmPath</code>.
+      </td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Others</td>
+      <td>
+        Untested. Use <code>wasmPath</code> if the default throws.
+      </td>
+      <td>No</td>
+    </tr>
+  </tbody>
+</table>
+
+When the default cannot work, serve the binary yourself and point at it:
+
+```bash
+cp node_modules/@wterm/ghostty/wasm/ghostty-vt.wasm public/ghostty-vt.wasm
+```
+
+```ts
+const core = await GhosttyCore.load({ wasmPath: "/ghostty-vt.wasm" });
+```
+
+The binary is also addressable as `@wterm/ghostty/ghostty-vt.wasm`, so a bundler with a URL import can take it directly.
+
 ## How it works
 
 `@wterm/ghostty` builds libghostty directly from [ghostty-org/ghostty](https://github.com/ghostty-org/ghostty) source — no third-party npm packages or pre-built binaries from other projects. The architecture:

--- a/packages/@wterm/ghostty/README.md
+++ b/packages/@wterm/ghostty/README.md
@@ -62,6 +62,34 @@ const core = await GhosttyCore.load();
 | `wasmPath` | `string` | Custom path to the ghostty-vt WASM binary |
 | `scrollbackLimit` | `number` | Maximum scrollback lines (default: 10000) |
 
+## Bundlers
+
+The WASM binary is fetched at runtime, not inlined, so the default has to resolve to a URL your app actually serves. `GhosttyCore.load()` resolves it with `new URL("../wasm/ghostty-vt.wasm", import.meta.url)`. Bundlers that implement that asset pattern emit the binary and rewrite the URL; ones that do not leave `import.meta.url` pointing at the machine that built the bundle.
+
+| Bundler | Default `GhosttyCore.load()` | Verified |
+|---|---|---|
+| Vite (dev and build) | works, emits a hashed asset | yes |
+| Bun dev server | fails, pass `wasmPath` | yes |
+| Others | untested, use `wasmPath` if the default throws | no |
+
+When the default cannot work, serve the binary yourself and point at it:
+
+```bash
+cp node_modules/@wterm/ghostty/wasm/ghostty-vt.wasm public/ghostty-vt.wasm
+```
+
+```ts
+const core = await GhosttyCore.load({ wasmPath: "/ghostty-vt.wasm" });
+```
+
+The binary is also addressable as `@wterm/ghostty/ghostty-vt.wasm`, so a bundler with a URL import can take it directly:
+
+```ts
+import wasmPath from "@wterm/ghostty/ghostty-vt.wasm?url";
+
+const core = await GhosttyCore.load({ wasmPath });
+```
+
 ## Architecture
 
 The WASM binary is built from upstream [ghostty-org/ghostty](https://github.com/ghostty-org/ghostty) (v1.3.1) using it as a Zig package dependency — no third-party npm packages or pre-built binaries from other projects.

--- a/packages/@wterm/ghostty/package.json
+++ b/packages/@wterm/ghostty/package.json
@@ -10,7 +10,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    }
+    },
+    "./ghostty-vt.wasm": "./wasm/ghostty-vt.wasm"
   },
   "files": [
     "dist",

--- a/packages/@wterm/ghostty/src/__tests__/wasm-loading.test.ts
+++ b/packages/@wterm/ghostty/src/__tests__/wasm-loading.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { loadGhosttyWasm } from "../wasm-bindings.js";
+
+const wasmBytes = readFileSync(
+  fileURLToPath(new URL("../../wasm/ghostty-vt.wasm", import.meta.url)),
+);
+
+const realFetch = globalThis.fetch;
+const realDocument = (globalThis as { document?: unknown }).document;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  if (realDocument === undefined) {
+    delete (globalThis as { document?: unknown }).document;
+  } else {
+    (globalThis as { document?: unknown }).document = realDocument;
+  }
+});
+
+function respondWith(body: BodyInit, init?: ResponseInit): void {
+  globalThis.fetch = (async () => new Response(body, init)) as typeof fetch;
+}
+
+describe("loadGhosttyWasm error reporting", () => {
+  it("names the cause when a bundler bakes a build-machine path", async () => {
+    // What Bun's dev server produces: import.meta.url survives as a file URL
+    // into browser code, where fetch reports only "Failed to fetch".
+    (globalThis as { document?: unknown }).document = {};
+
+    await expect(loadGhosttyWasm()).rejects.toThrow(/bundler resolved/);
+    await expect(loadGhosttyWasm()).rejects.toThrow(/wasmPath/);
+  });
+
+  it("leaves an explicit wasmPath alone", async () => {
+    (globalThis as { document?: unknown }).document = {};
+    respondWith(wasmBytes);
+
+    await expect(
+      loadGhosttyWasm("file:///somewhere/ghostty-vt.wasm"),
+    ).resolves.toHaveProperty("exports");
+  });
+
+  it("reports the status when the URL 404s", async () => {
+    respondWith("<!doctype html>not found", {
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    await expect(
+      loadGhosttyWasm("https://wterm.test/missing.wasm"),
+    ).rejects.toThrow(/404/);
+  });
+
+  it("reports a non-WASM body rather than a magic-word error", async () => {
+    respondWith("<!doctype html><title>index</title>");
+
+    await expect(
+      loadGhosttyWasm("https://wterm.test/index.html"),
+    ).rejects.toThrow(/did not return a WASM module/);
+  });
+
+  it("still loads a served binary", async () => {
+    respondWith(wasmBytes);
+
+    const wasm = await loadGhosttyWasm("https://wterm.test/ghostty-vt.wasm");
+    expect(typeof wasm.exports.init).toBe("function");
+  });
+});

--- a/packages/@wterm/ghostty/src/wasm-bindings.ts
+++ b/packages/@wterm/ghostty/src/wasm-bindings.ts
@@ -64,8 +64,31 @@ export interface GhosttyWasm {
 
 const CELL_BYTES = 16;
 
-const DEFAULT_WASM_PATH = new URL("../wasm/ghostty-vt.wasm", import.meta.url)
-  .href;
+const REMEDY =
+  "Serve the binary from your app and pass its URL: " +
+  'GhosttyCore.load({ wasmPath: "/ghostty-vt.wasm" }). The file ships with ' +
+  "the package as @wterm/ghostty/ghostty-vt.wasm. See the Bundlers section " +
+  "of the @wterm/ghostty README.";
+
+/**
+ * Resolve the binary that ships with the package.
+ *
+ * Bundlers that implement the `new URL(..., import.meta.url)` asset pattern
+ * rewrite this to an emitted asset. Ones that do not leave `import.meta.url`
+ * pointing at the build machine's copy of this file.
+ */
+function defaultWasmUrl(): string {
+  return new URL("../wasm/ghostty-vt.wasm", import.meta.url).href;
+}
+
+/** `\0asm`. A 404 HTML page otherwise dies as "expected magic word". */
+function hasWasmMagic(bytes: ArrayBuffer): boolean {
+  if (bytes.byteLength < 4) return false;
+  const head = new Uint8Array(bytes, 0, 4);
+  return (
+    head[0] === 0x00 && head[1] === 0x61 && head[2] === 0x73 && head[3] === 0x6d
+  );
+}
 
 /**
  * Load the ghostty-vt WASM module.
@@ -74,9 +97,37 @@ const DEFAULT_WASM_PATH = new URL("../wasm/ghostty-vt.wasm", import.meta.url)
  *   committed binary at `../wasm/ghostty-vt.wasm`.
  */
 export async function loadGhosttyWasm(wasmUrl?: string): Promise<GhosttyWasm> {
-  const url = wasmUrl ?? DEFAULT_WASM_PATH;
+  const url = wasmUrl ?? defaultWasmUrl();
+
+  // A file: URL in a browser is a build-machine path that survived bundling.
+  // fetch() reports it as a bare "Failed to fetch", which names neither the
+  // cause nor the fix.
+  if (
+    wasmUrl === undefined &&
+    url.startsWith("file:") &&
+    typeof document !== "undefined"
+  ) {
+    throw new Error(
+      `@wterm/ghostty: your bundler resolved the WASM URL to ${url}, a path ` +
+        `on the machine that built the bundle, so the browser cannot fetch ` +
+        `it. ${REMEDY}`,
+    );
+  }
+
   const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `@wterm/ghostty: fetching ${url} returned ${response.status} ` +
+        `${response.statusText}. ${REMEDY}`,
+    );
+  }
+
   const bytes = await response.arrayBuffer();
+  if (!hasWasmMagic(bytes)) {
+    throw new Error(
+      `@wterm/ghostty: ${url} did not return a WASM module. ${REMEDY}`,
+    );
+  }
 
   let wasmMemory: WebAssembly.Memory;
 


### PR DESCRIPTION
`GhosttyCore.load()` resolves the binary with `new URL("../wasm/ghostty-vt.wasm", import.meta.url)`. Bun's dev server resolves `import.meta.url` to the source path on the build machine, so a `file:` URL reaches the browser and `fetch` reports only `Failed to fetch`.

Fixes #82.

## What changed

The default is unchanged. Driving the Vite example in a browser shows it already works on dev and on build, where it emits a hashed asset, so replacing the pattern would regress the setup that needs no configuration in order to fix one that does.

What changed is the failure. The URL is resolved lazily, and a default that came out as `file:` in a browser throws before fetching, naming the cause and pointing at `wasmPath`. Non-OK responses report their status. A body without the `\0asm` magic is reported as such instead of dying inside `WebAssembly.instantiate` as "expected magic word".

`wasm/ghostty-vt.wasm` is now a subpath export. The remedy the error suggests was not addressable through the package's `exports`, which only had `"."`.

## How to check it

Bun 1.3.14 dev server, before and after:

```
before   Failed to fetch
after    @wterm/ghostty: your bundler resolved the WASM URL to file:///…/ghostty-vt.wasm,
         a path on the machine that built the bundle, so the browser cannot fetch it.
         Serve the binary from your app and pass its URL: GhosttyCore.load({ wasmPath: "/ghostty-vt.wasm" }) …
```

Vite is unaffected, driven in Chromium on both paths:

```
vite dev             rows=40  wasm=/@fs/…/ghostty-vt.wasm            errors=none
vite build+preview   rows=40  wasm=/assets/ghostty-vt-DIMU6khE.wasm  errors=none
```

The binary stays out of the JS bundle: the example's JS grows 796 bytes against `main`, and the only base64 WASM in it is `@wterm/core`'s, which is inlined by design and present on `main` too.

Five tests cover the file-URL guard, an explicit `wasmPath` bypassing it, a 404, a non-WASM body, and a served binary. The existing suites are unchanged.

## Coverage

The README and docs now state what is verified rather than implying the rest. Vite dev and build are verified working; Bun is verified failing with the new message; every other bundler is marked untested with `wasmPath` as the fallback.

The issue says the default works in Next.js. That is not what the repo shows: `examples/local` copies the binary into `public/` in a `predev` hook and passes an explicit `wasmPath`, so it never exercises the default.