### PR TITLE
Keep focused cursor visible over cell backgrounds

### DIFF
--- a/packages/@wterm/dom/src/__tests__/renderer.test.ts
+++ b/packages/@wterm/dom/src/__tests__/renderer.test.ts
@@ -275,6 +275,46 @@ describe("Renderer", () => {
       expect(cursor?.textContent).toBe("A");
     });
 
+    it("keeps explicit cell colors overridable on cursor spans", () => {
+      const grid = [[makeCell("A", 1, 4)]];
+      const bridge = createMockBridge(1, 1, grid);
+      bridge.getCursor = () => ({ row: 0, col: 0, visible: true });
+      const renderer = new Renderer(container);
+      renderer.render(bridge as any);
+
+      const style = container
+        .querySelector(".term-cursor")
+        ?.getAttribute("style");
+      expect(style).toContain("--term-cell-fg:var(--term-color-1);");
+      expect(style).toContain("--term-cell-bg:var(--term-color-4);");
+      expect(style).not.toMatch(/(?:^|;)(?:color|background):/);
+    });
+
+    it("keeps explicit backgrounds overridable for wide, block, and blank cursors", () => {
+      const cases: CellData[][] = [
+        [
+          makeCell("界", 1, 4, 0, 2),
+          { char: 0, fg: 1, bg: 4, flags: 0, width: 0 },
+        ],
+        [makeCell("█", 1, 4)],
+        [{ char: 0, fg: 1, bg: 4, flags: 0, width: 1 }],
+      ];
+
+      for (const grid of cases) {
+        const caseContainer = document.createElement("div");
+        document.body.appendChild(caseContainer);
+        const bridge = createMockBridge(grid.length, 1, [grid]);
+        bridge.getCursor = () => ({ row: 0, col: 0, visible: true });
+        new Renderer(caseContainer).render(bridge as any);
+
+        const style = caseContainer
+          .querySelector(".term-cursor")
+          ?.getAttribute("style");
+        expect(style).toContain("--term-cell-bg:");
+        expect(style).not.toMatch(/(?:^|;)(?:color|background):/);
+      }
+    });
+
     it("re-renders on resize", () => {
       const bridge1 = createMockBridge(2, 1, [[makeCell("X")]]);
       const renderer = new Renderer(container);
@@ -300,6 +340,7 @@ describe("Renderer", () => {
     it("applies styled spans for colored cells", () => {
       const grid = [[makeCell("C", 1, 256, 0)]];
       const bridge = createMockBridge(1, 1, grid);
+      bridge.getCursor = () => ({ row: 0, col: 0, visible: false });
       const renderer = new Renderer(container);
       renderer.render(bridge as any);
 

--- a/packages/@wterm/dom/src/renderer.ts
+++ b/packages/@wterm/dom/src/renderer.ts
@@ -93,6 +93,16 @@ function buildCellStyle(
   return style;
 }
 
+// Cell colors are normally inline styles so each run can be painted without
+// extra classes. Cursor styles need to remain overridable by the focused
+// cursor rule, though, so move only those two declarations to custom
+// properties when a cursor span reuses a cell style.
+function cursorCellStyle(style: string): string {
+  return style
+    .replace(/(^|;)color:/g, "$1--term-cell-fg:")
+    .replace(/(^|;)background:/g, "$1--term-cell-bg:");
+}
+
 function appendRun(parent: HTMLElement, text: string, style: string): void {
   const span = document.createElement("span");
   if (style) span.style.cssText = style;
@@ -345,8 +355,9 @@ export class Renderer {
             ? `<span style="${runStyle}">${escapeHTML(before)}</span>`
             : `<span>${escapeHTML(before)}</span>`;
         }
-        content += runStyle
-          ? `<span class="term-cursor" style="${runStyle}">${escapeHTML(cursorChar)}</span>`
+        const cursorStyle = cursorCellStyle(runStyle);
+        content += cursorStyle
+          ? `<span class="term-cursor" style="${cursorStyle}">${escapeHTML(cursorChar)}</span>`
           : `<span class="term-cursor">${escapeHTML(cursorChar)}</span>`;
         if (after) {
           content += runStyle
@@ -395,9 +406,17 @@ export class Renderer {
         // would shorten the row.
         const continuesWide = col > 0 && (getCell(col - 1).width ?? 1) === 2;
         if (!continuesWide) {
+          const style = buildCellStyle(
+            cell.fg,
+            cell.bg,
+            cell.flags,
+            cell.fgRgb,
+            cell.bgRgb,
+          );
+          const cursor = col === cursorCol;
           appendStyledSpan(
-            col === cursorCol ? "term-cursor" : "",
-            "",
+            cursor ? "term-cursor" : "",
+            cursor ? cursorCellStyle(style) : style,
             " ",
             cellLinkKey,
             cellLinkUri,
@@ -420,9 +439,17 @@ export class Renderer {
         // continuation is outside the row. Drawing the pair here would spill
         // a second column past the row.
         if (col + 1 >= this.cols) {
+          const style = buildCellStyle(
+            cell.fg,
+            cell.bg,
+            cell.flags,
+            cell.fgRgb,
+            cell.bgRgb,
+          );
+          const cursor = col === cursorCol;
           appendStyledSpan(
-            col === cursorCol ? "term-cursor" : "",
-            "",
+            cursor ? "term-cursor" : "",
+            cursor ? cursorCellStyle(style) : style,
             " ",
             cellLinkKey,
             cellLinkUri,
@@ -444,11 +471,15 @@ export class Renderer {
           cell.fgRgb,
           cell.bgRgb,
         );
-        const cls =
-          cursorCol >= col && cursorCol < col + 2
-            ? "term-wide term-cursor"
-            : "term-wide";
-        appendStyledSpan(cls, style, ch, cellLinkKey, cellLinkUri);
+        const cursor = cursorCol >= col && cursorCol < col + 2;
+        const cls = cursor ? "term-wide term-cursor" : "term-wide";
+        appendStyledSpan(
+          cls,
+          cursor ? cursorCellStyle(style) : style,
+          ch,
+          cellLinkKey,
+          cellLinkUri,
+        );
 
         runStyle = "";
         runLinkKey = "";
@@ -472,8 +503,12 @@ export class Renderer {
         const cls = col === cursorCol ? "term-block term-cursor" : "term-block";
         const bg = getBlockBackground(cp, colors.fg, colors.bg);
         const dim = cell.flags & FLAG_DIM ? "opacity:0.5;" : "";
+        const blockStyle =
+          col === cursorCol
+            ? `--term-cell-bg:${bg};${dim}`
+            : `background:${bg};${dim}`;
         appendContent(
-          `<span class="${cls}" style="background:${bg};${dim}"></span>`,
+          `<span class="${cls}" style="${blockStyle}"></span>`,
           cellLinkKey,
           cellLinkUri,
         );

--- a/packages/@wterm/dom/src/terminal.css
+++ b/packages/@wterm/dom/src/terminal.css
@@ -114,6 +114,8 @@
 }
 
 .term-cursor {
+  color: var(--term-cell-fg, inherit);
+  background: var(--term-cell-bg, transparent);
   outline: 1px solid var(--term-cursor);
   outline-offset: -1px;
 }


### PR DESCRIPTION
Focused cursor spans now store per-cell foreground and background colors in CSS custom properties, allowing focused cursor styling to take precedence over cell backgrounds. The behavior is applied consistently to regular, wide, block, and blank cells while preserving the unfocused outline and optional blinking behavior.

Closes #88