### PR TITLE
Prepare the v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
-## 0.3.4
+## 0.4.0
 
 <!-- release:start -->
+
+### New Features
+
+- **Kitty keyboard protocol:** the built-in and Ghostty cores negotiate Kitty keyboard reporting, while the DOM renderer encodes browser keyboard events using the active terminal state.
+- **Kitty terminal images:** Ghostty-backed terminals render bounded direct PNG, RGB, and RGBA graphics through the optional terminal graphics API and a scroll-aware canvas overlay.
+
+### Bug Fixes
+
+- **Fractional scroll ownership:** the DOM renderer preserves follow mode when browser reclamping changes the scroll position during terminal updates.
+
+### Contributors
+
+- @ctate
+- @Railly
+
+<!-- release:end -->
+
+## 0.3.4
 
 ### New Features
 
@@ -22,8 +40,6 @@
 ### Contributors
 
 - @Railly
-
-<!-- release:end -->
 
 ## 0.3.3
 

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/core",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Headless terminal emulator core for the web — WASM bridge and WebSocket transport",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/dom",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "DOM renderer, input handler, and orchestrator for wterm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/ghostty/package.json
+++ b/packages/@wterm/ghostty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/ghostty",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "libghostty-powered terminal core for wterm — full-featured VT emulation via Ghostty's WASM build",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/just-bash",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "just-bash shell adapter for wterm — line editing, tab completion, history, prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/markdown",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Streaming markdown-to-ANSI renderer for wterm terminals",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/react",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "React component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/vue/package.json
+++ b/packages/@wterm/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/vue",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Vue component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Prepare the v0.4.0 release for the settled terminal functionality updates:

- Document Kitty keyboard protocol negotiation in the built-in and Ghostty cores and browser-key encoding in the DOM renderer.
- Document bounded Kitty PNG, RGB, and RGBA graphics for Ghostty-backed terminals with scroll-aware canvas rendering.
- Document the fractional-scroll ownership fix that preserves follow mode during browser reclamping.
- Synchronize all seven `@wterm/*` package versions to `0.4.0`.

These release notes and package metadata align the published release with the completed terminal behavior changes.