### PR TITLE
chore: prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
-## 0.4.0
+## 0.4.1
 
 <!-- release:start -->
+
+### New Features
+
+- **Local terminal workspace:** the local example now supports multiple independent shell sessions with an accessible sidebar for creating, switching, and closing sessions, plus live working-directory labels.
+- **Kitty image sizing and geometry:** DOM terminals answer Kitty pixel-geometry queries, configurable image bounds preserve aspect ratio, and the local PTY forwards browser dimensions so Kitty clients can detect image support.
+
+### Improvements
+
+- **Implicit image flow:** auto-sized Kitty images align with the terminal content and reserve their rendered height, keeping following shell prompts visible below the image.
+- **Local example core switching:** built-in and Ghostty terminal sessions share the workspace while the Ghostty route enables bounded Kitty image rendering.
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.4.0
 
 ### New Features
 
@@ -17,8 +35,6 @@
 
 - @ctate
 - @Railly
-
-<!-- release:end -->
 
 ## 0.3.4
 

--- a/packages/@wterm/core/package.json
+++ b/packages/@wterm/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Headless terminal emulator core for the web — WASM bridge and WebSocket transport",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/dom/package.json
+++ b/packages/@wterm/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/dom",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "DOM renderer, input handler, and orchestrator for wterm",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/ghostty/package.json
+++ b/packages/@wterm/ghostty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/ghostty",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "libghostty-powered terminal core for wterm — full-featured VT emulation via Ghostty's WASM build",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/just-bash/package.json
+++ b/packages/@wterm/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/just-bash",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "just-bash shell adapter for wterm — line editing, tab completion, history, prompt",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/markdown/package.json
+++ b/packages/@wterm/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/markdown",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Streaming markdown-to-ANSI renderer for wterm terminals",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/react/package.json
+++ b/packages/@wterm/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/react",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "React component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/@wterm/vue/package.json
+++ b/packages/@wterm/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wterm/vue",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Vue component for wterm — a terminal emulator for the web",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
- Bump all @wterm packages to 0.4.1
- Document the local multi-session workspace and Kitty graphics improvements
- Move the changelog release markers to 0.4.1