### PR TITLE
feat: add Svelte support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           LOCAL_VERSION=$(node -p "require('./packages/@wterm/core/package.json').version")
           SHOULD_RELEASE=false
-          for pkg in core dom react vue just-bash markdown ghostty; do
+          for pkg in core dom react vue svelte just-bash markdown ghostty; do
             REGISTRY_VERSION=$(npm view "@wterm/$pkg" version 2>/dev/null || echo "0.0.0")
             echo "@wterm/$pkg — local: $LOCAL_VERSION, registry: $REGISTRY_VERSION"
             if [ "$LOCAL_VERSION" != "$REGISTRY_VERSION" ]; then
@@ -93,7 +93,7 @@ jobs:
             fi
           }
 
-          for pkg in core dom react vue just-bash markdown ghostty; do
+          for pkg in core dom react vue svelte just-bash markdown ghostty; do
             publish_pkg "packages/@wterm/$pkg" "@wterm/$pkg"
           done
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 .turbo/
 *.tsbuildinfo
 .next/
+.svelte-kit/
 next-env.d.ts
 packages/@wterm/core/src/wasm-inline.ts
 coverage/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ wterm ("dub-term") renders to the DOM — native text selection, copy/paste, fin
 | [`@wterm/dom`](packages/@wterm/dom) | DOM renderer, input handler — vanilla JS terminal |
 | [`@wterm/react`](packages/@wterm/react) | React component + `useTerminal` hook (TypeScript) |
 | [`@wterm/vue`](packages/@wterm/vue) | Vue 3 component + template ref API |
+| [`@wterm/svelte`](packages/@wterm/svelte) | Svelte component + callback/event API |
 | [`@wterm/ghostty`](packages/@wterm/ghostty) | Full-featured VT emulation core powered by libghostty |
 | [`@wterm/just-bash`](packages/@wterm/just-bash) | In-browser Bash shell powered by just-bash |
 | [`@wterm/markdown`](packages/@wterm/markdown) | Render Markdown in the terminal |
@@ -33,6 +34,7 @@ wterm ("dub-term") renders to the DOM — native text selection, copy/paste, fin
 - **Kitty terminal images** — Ghostty-backed terminals render direct PNG/RGB/RGBA graphics in a scroll-aware canvas overlay with configurable display bounds; implicit image placements keep following prompts visually below the image
 - **24-bit color** — full RGB SGR support
 - **Auto-resize** — `ResizeObserver`-based terminal resizing
+- **Framework bindings** — React, Vue 3, and Svelte components
 - **WebSocket transport** — connect to a PTY backend with binary framing and reconnection
 - **Mouse and focus reporting** — DOM input for SGR mouse tracking and terminal focus events
 - **Kitty keyboard protocol**: negotiated key disambiguation, event types, alternate keys, all-key reporting, and associated text

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ wterm ("dub-term") renders to the DOM — native text selection, copy/paste, fin
 | [`@wterm/dom`](packages/@wterm/dom) | DOM renderer, input handler — vanilla JS terminal |
 | [`@wterm/react`](packages/@wterm/react) | React component + `useTerminal` hook (TypeScript) |
 | [`@wterm/vue`](packages/@wterm/vue) | Vue 3 component + template ref API |
-| [`@wterm/svelte`](packages/@wterm/svelte) | Svelte component + callback/event API |
+| [`@wterm/svelte`](packages/@wterm/svelte) | Svelte component + callback API |
 | [`@wterm/ghostty`](packages/@wterm/ghostty) | Full-featured VT emulation core powered by libghostty |
 | [`@wterm/just-bash`](packages/@wterm/just-bash) | In-browser Bash shell powered by just-bash |
 | [`@wterm/markdown`](packages/@wterm/markdown) | Render Markdown in the terminal |

--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ cp web/wterm.wasm examples/nextjs/public/
 pnpm --filter nextjs dev
 ```
 
+### Run the Svelte example
+
+The Svelte example uses `@wterm/svelte` with an in-browser `just-bash` shell,
+theme switching, and imperative terminal controls:
+
+```bash
+pnpm --filter svelte-example dev
+```
+
+It opens at `svelte-example.wterm.localhost` through Portless.
+
 ### Run Zig tests
 
 ```bash

--- a/apps/docs/src/app/api-reference/page.mdx
+++ b/apps/docs/src/app/api-reference/page.mdx
@@ -260,8 +260,7 @@ The Vue `<Terminal>` component adds these props on top of the shared options abo
 
 The Svelte `<Terminal>` component adds `theme` and forwards standard HTML
 attributes such as `class`, `style`, `id`, and ARIA attributes to its root
-`div`. Svelte 5 callback props are listed below. The legacy `on:event` syntax
-is also supported for the events that follow.
+`div`. Svelte 5 callback props are listed below.
 
 <table>
   <thead>
@@ -301,49 +300,6 @@ is also supported for the events that follow.
       <td><code>onError</code></td>
       <td><code>(error: unknown) =&gt; void</code></td>
       <td>Called if WASM loading or initialization fails.</td>
-    </tr>
-  </tbody>
-</table>
-
-## Svelte Events
-
-The component dispatches these events for Svelte's legacy <code>on:event</code>
-syntax. The <code>resize</code> event carries a <code>[cols, rows]</code> tuple
-in <code>event.detail</code>; the other events carry their value directly.
-
-<table>
-  <thead>
-    <tr>
-      <th>Event</th>
-      <th>Detail</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>data</code></td>
-      <td><code>string</code></td>
-      <td>Terminal input or a host response, when an <code>onData</code>/<code>ondata</code> callback or legacy listener is configured.</td>
-    </tr>
-    <tr>
-      <td><code>title</code></td>
-      <td><code>string</code></td>
-      <td>Terminal title changes.</td>
-    </tr>
-    <tr>
-      <td><code>resize</code></td>
-      <td><code>[cols: number, rows: number]</code></td>
-      <td>Terminal dimensions after a resize.</td>
-    </tr>
-    <tr>
-      <td><code>ready</code></td>
-      <td><code>WTerm</code></td>
-      <td>Emitted after initialization completes.</td>
-    </tr>
-    <tr>
-      <td><code>error</code></td>
-      <td><code>unknown</code></td>
-      <td>Emitted if initialization fails.</td>
     </tr>
   </tbody>
 </table>

--- a/apps/docs/src/app/api-reference/page.mdx
+++ b/apps/docs/src/app/api-reference/page.mdx
@@ -323,7 +323,7 @@ in <code>event.detail</code>; the other events carry their value directly.
     <tr>
       <td><code>data</code></td>
       <td><code>string</code></td>
-      <td>Terminal input or a host response, when an <code>onData</code> callback is configured.</td>
+      <td>Terminal input or a host response, when an <code>onData</code>/<code>ondata</code> callback or legacy listener is configured.</td>
     </tr>
     <tr>
       <td><code>title</code></td>

--- a/apps/docs/src/app/api-reference/page.mdx
+++ b/apps/docs/src/app/api-reference/page.mdx
@@ -78,7 +78,7 @@ those browser limits are skipped.
 
 ## Terminal Options
 
-The React and Vue `<Terminal>` components and the vanilla `WTerm` constructor all accept these options:
+The React, Vue, and Svelte `<Terminal>` components and the vanilla `WTerm` constructor all accept these options:
 
 <table>
   <thead>
@@ -117,7 +117,7 @@ The React and Vue `<Terminal>` components and the vanilla `WTerm` constructor al
     <tr>
       <td><code>autoResize</code></td>
       <td><code>boolean</code></td>
-      <td><code>true</code> (vanilla) / <code>false</code> (React, Vue)</td>
+      <td><code>true</code> (vanilla) / <code>false</code> (React, Vue, Svelte)</td>
       <td>Automatically resize the terminal to fit its container using a <code>ResizeObserver</code></td>
     </tr>
     <tr>
@@ -256,6 +256,98 @@ The Vue `<Terminal>` component adds these props on top of the shared options abo
   </tbody>
 </table>
 
+## Svelte-only Props
+
+The Svelte `<Terminal>` component adds `theme` and forwards standard HTML
+attributes such as `class`, `style`, `id`, and ARIA attributes to its root
+`div`. Svelte 5 callback props are listed below. The legacy `on:event` syntax
+is also supported for the events that follow.
+
+<table>
+  <thead>
+    <tr>
+      <th>Prop</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>theme</code></td>
+      <td><code>string</code></td>
+      <td>Name of a built-in or custom theme (see <a href="/themes">Themes</a>). Applied as a <code>theme-&lt;name&gt;</code> class.</td>
+    </tr>
+    <tr>
+      <td><code>onData</code></td>
+      <td><code>(data: string) =&gt; void</code></td>
+      <td>Called for terminal input and host responses. When omitted, input is echoed automatically.</td>
+    </tr>
+    <tr>
+      <td><code>onTitle</code></td>
+      <td><code>(title: string) =&gt; void</code></td>
+      <td>Called when the terminal title changes.</td>
+    </tr>
+    <tr>
+      <td><code>onResize</code></td>
+      <td><code>(cols: number, rows: number) =&gt; void</code></td>
+      <td>Called after the terminal is resized.</td>
+    </tr>
+    <tr>
+      <td><code>onReady</code></td>
+      <td><code>(wt: WTerm) =&gt; void</code></td>
+      <td>Called after WASM loads and initialization completes.</td>
+    </tr>
+    <tr>
+      <td><code>onError</code></td>
+      <td><code>(error: unknown) =&gt; void</code></td>
+      <td>Called if WASM loading or initialization fails.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Svelte Events
+
+The component dispatches these events for Svelte's legacy <code>on:event</code>
+syntax. The <code>resize</code> event carries a <code>[cols, rows]</code> tuple
+in <code>event.detail</code>; the other events carry their value directly.
+
+<table>
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Detail</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>data</code></td>
+      <td><code>string</code></td>
+      <td>Terminal input or a host response, when an <code>onData</code> callback is configured.</td>
+    </tr>
+    <tr>
+      <td><code>title</code></td>
+      <td><code>string</code></td>
+      <td>Terminal title changes.</td>
+    </tr>
+    <tr>
+      <td><code>resize</code></td>
+      <td><code>[cols: number, rows: number]</code></td>
+      <td>Terminal dimensions after a resize.</td>
+    </tr>
+    <tr>
+      <td><code>ready</code></td>
+      <td><code>WTerm</code></td>
+      <td>Emitted after initialization completes.</td>
+    </tr>
+    <tr>
+      <td><code>error</code></td>
+      <td><code>unknown</code></td>
+      <td>Emitted if initialization fails.</td>
+    </tr>
+  </tbody>
+</table>
+
 ## WTerm Methods
 
 Instance methods on the vanilla `WTerm` class:
@@ -302,7 +394,6 @@ The `useTerminal` hook returns a ref and convenience methods that delegate to th
 ```tsx
 const { ref, write, resize, focus } = useTerminal();
 ```
-
 <table>
   <thead>
     <tr>
@@ -394,6 +485,60 @@ const term = useTemplateRef("term");
     </tr>
   </tbody>
 </table>
+
+## Imperative Handle (Svelte)
+
+Bind the Svelte component instance to access its imperative methods:
+
+```svelte
+<script lang="ts">
+import { Terminal, type TerminalHandle } from "@wterm/svelte";
+
+let terminal: TerminalHandle;
+</script>
+
+<Terminal bind:this={terminal} />
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Member</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>write</code></td>
+      <td><code>(data: string | Uint8Array) =&gt; void</code></td>
+      <td>Write data to the terminal. Calls before initialization are ignored.</td>
+    </tr>
+    <tr>
+      <td><code>resize</code></td>
+      <td><code>(cols: number, rows: number) =&gt; void</code></td>
+      <td>Resize the terminal grid.</td>
+    </tr>
+    <tr>
+      <td><code>focus</code></td>
+      <td><code>() =&gt; void</code></td>
+      <td>Focus the terminal input.</td>
+    </tr>
+  </tbody>
+</table>
+
+To access the underlying <code>WTerm</code>, bind the component's
+<code>instance</code> prop:
+
+```svelte
+<script lang="ts">
+import { Terminal, type WTerm } from "@wterm/svelte";
+
+let instance: WTerm | null = null;
+</script>
+
+<Terminal bind:instance />
+```
 
 ## WebSocketTransport
 

--- a/apps/docs/src/app/api/docs-chat/route.ts
+++ b/apps/docs/src/app/api/docs-chat/route.ts
@@ -16,7 +16,7 @@ const SYSTEM_PROMPT = `You are a helpful documentation assistant for wterm ("dub
 
 GitHub repository: https://github.com/vercel-labs/wterm
 Documentation: https://wterm.dev
-npm packages: @wterm/core, @wterm/dom, @wterm/react, @wterm/vue, @wterm/markdown, @wterm/just-bash
+npm packages: @wterm/core, @wterm/dom, @wterm/react, @wterm/vue, @wterm/svelte, @wterm/markdown, @wterm/just-bash
 
 You have access to the full wterm documentation via the bash and readFile tools. The docs are available as markdown files in the /workspace/ directory.
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -2,7 +2,7 @@
 
 ## Options
 
-The React, Vue, and Svelte `Terminal` components and the vanilla `WTerm` constructor accept the same core options — `cols`, `rows`, `core`, `wasmUrl`, `autoResize`, `maxImageWidth`, `maxImageHeight`, `cursorBlink`, and `debug` — plus event callbacks `onData`, `onTitle`, and `onResize` (exposed as `@data`, `@title`, and `@resize` events in Vue, or `on:event` events in Svelte).
+The React, Vue, and Svelte `Terminal` components and the vanilla `WTerm` constructor accept the same core options — `cols`, `rows`, `core`, `wasmUrl`, `autoResize`, `maxImageWidth`, `maxImageHeight`, `cursorBlink`, and `debug` — plus event callbacks `onData`, `onTitle`, and `onResize` (exposed as `@data`, `@title`, and `@resize` events in Vue).
 
 See the full [API Reference](/api-reference#terminal-options) for types, defaults, and descriptions.
 
@@ -37,9 +37,9 @@ See [Vue-Only Props](/api-reference#vue-only-props) and [Vue Events](/api-refere
 The Svelte `Terminal` component adds the `theme` prop and forwards standard
 `<div>` attributes such as `class`, `style`, `id`, and ARIA attributes. Svelte 5
 applications can use the `onData`, `onTitle`, `onResize`, `onReady`, and
-`onError` callback props. Svelte's legacy `on:event` syntax is also supported.
+`onError` callback props.
 
-See [Svelte-only Props](/api-reference#svelte-only-props) and [Svelte Events](/api-reference#svelte-events) for details.
+See [Svelte-only Props](/api-reference#svelte-only-props) for details.
 
 ## Imperative Handle (React)
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -2,7 +2,7 @@
 
 ## Options
 
-The React and Vue `Terminal` components and the vanilla `WTerm` constructor accept the same core options — `cols`, `rows`, `core`, `wasmUrl`, `autoResize`, `maxImageWidth`, `maxImageHeight`, `cursorBlink`, and `debug` — plus event callbacks `onData`, `onTitle`, and `onResize` (exposed as `@data`, `@title`, `@resize` events in Vue).
+The React, Vue, and Svelte `Terminal` components and the vanilla `WTerm` constructor accept the same core options — `cols`, `rows`, `core`, `wasmUrl`, `autoResize`, `maxImageWidth`, `maxImageHeight`, `cursorBlink`, and `debug` — plus event callbacks `onData`, `onTitle`, and `onResize` (exposed as `@data`, `@title`, and `@resize` events in Vue, or `on:event` events in Svelte).
 
 See the full [API Reference](/api-reference#terminal-options) for types, defaults, and descriptions.
 
@@ -31,6 +31,15 @@ See [React-Only Props](/api-reference#react-only-props) for details.
 The Vue `Terminal` component adds a `theme` prop. `onReady` and `onError` are exposed as `@ready` and `@error` events instead of props. Standard DOM attributes (`class`, `style`, `id`, ARIA props, etc.) are forwarded to the root `<div>` via the default `inheritAttrs` behavior.
 
 See [Vue-Only Props](/api-reference#vue-only-props) and [Vue Events](/api-reference#vue-events) for details.
+
+### Svelte-only
+
+The Svelte `Terminal` component adds the `theme` prop and forwards standard
+`<div>` attributes such as `class`, `style`, `id`, and ARIA attributes. Svelte 5
+applications can use the `onData`, `onTitle`, `onResize`, `onReady`, and
+`onError` callback props. Svelte's legacy `on:event` syntax is also supported.
+
+See [Svelte-only Props](/api-reference#svelte-only-props) and [Svelte Events](/api-reference#svelte-events) for details.
 
 ## Imperative Handle (React)
 
@@ -77,6 +86,22 @@ function onReady(wt: WTerm) {
 ```
 
 See the full [Template Ref (Vue)](/api-reference#template-ref-vue) reference for all exposed methods.
+
+## Imperative Handle (Svelte)
+
+Bind the Svelte component instance to call its imperative methods:
+
+```svelte
+<script lang="ts">
+import { Terminal, type TerminalHandle } from "@wterm/svelte";
+
+let terminal: TerminalHandle;
+</script>
+
+<Terminal bind:this={terminal} />
+```
+
+See the full [Imperative Handle (Svelte)](/api-reference#imperative-handle-svelte) reference for all exposed methods.
 
 ## WebSocket Transport
 

--- a/apps/docs/src/app/get-started/page.mdx
+++ b/apps/docs/src/app/get-started/page.mdx
@@ -14,6 +14,12 @@ npm install @wterm/dom @wterm/react
 npm install @wterm/dom @wterm/vue
 ```
 
+### Svelte
+
+```bash
+npm install @wterm/dom @wterm/svelte svelte
+```
+
 ### Vanilla JS
 
 ```bash
@@ -46,6 +52,17 @@ import "@wterm/vue/css";
 <template>
   <Terminal />
 </template>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+import { Terminal } from "@wterm/svelte";
+import "@wterm/svelte/css";
+</script>
+
+<Terminal />
 ```
 
 ### Vanilla JS

--- a/apps/docs/src/app/ghostty/page.mdx
+++ b/apps/docs/src/app/ghostty/page.mdx
@@ -72,13 +72,22 @@ const core = await GhosttyCore.load();
 
 ```svelte
 <script lang="ts">
+import { onMount } from "svelte";
 import { Terminal } from "@wterm/svelte";
 import { GhosttyCore } from "@wterm/ghostty";
 
-const core = await GhosttyCore.load();
+let core: GhosttyCore | undefined;
+
+onMount(() => {
+  void GhosttyCore.load().then((loaded) => {
+    core = loaded;
+  });
+});
 </script>
 
-<Terminal {core} />
+{#if core}
+  <Terminal {core} />
+{/if}
 ```
 
 For large Kitty images, pass display limits to the terminal wrapper. The

--- a/apps/docs/src/app/ghostty/page.mdx
+++ b/apps/docs/src/app/ghostty/page.mdx
@@ -68,6 +68,19 @@ const core = await GhosttyCore.load();
 </template>
 ```
 
+### Svelte
+
+```svelte
+<script lang="ts">
+import { Terminal } from "@wterm/svelte";
+import { GhosttyCore } from "@wterm/ghostty";
+
+const core = await GhosttyCore.load();
+</script>
+
+<Terminal {core} />
+```
+
 For large Kitty images, pass display limits to the terminal wrapper. The
 limits are CSS pixels, preserve the image aspect ratio, and only scale images
 down:
@@ -80,7 +93,8 @@ const term = new WTerm(document.getElementById("terminal"), {
 });
 ```
 
-The equivalent React and Vue props are `maxImageWidth` and `maxImageHeight`.
+The equivalent React, Vue, and Svelte props are `maxImageWidth` and
+`maxImageHeight`.
 
 `WTerm` answers Kitty's pixel geometry queries from the browser viewport, so
 direct image commands such as `kitten icat --transfer-mode=stream image.png`

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -28,5 +28,6 @@ import { HeroSection } from "@/components/hero-terminal";
 - **Scrollback history** — configurable ring buffer
 - **Wide Unicode cells** — CJK, fullwidth, and emoji codepoints stay aligned during cursor-addressed redraws
 - **24-bit color** — full RGB SGR support
+- **Framework bindings** — React, Vue 3, and Svelte components
 - **Auto-resize** — `ResizeObserver`-based terminal resizing
 - **WebSocket transport** — connect to a PTY backend with reconnection

--- a/apps/docs/src/app/svelte/layout.tsx
+++ b/apps/docs/src/app/svelte/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from "@/lib/page-metadata";
+
+export const metadata = pageMetadata("svelte");
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/docs/src/app/svelte/page.mdx
+++ b/apps/docs/src/app/svelte/page.mdx
@@ -61,18 +61,6 @@ core such as `@wterm/ghostty` automatically renders direct Kitty PNG/RGB/RGBA
 images. Set `maxImageWidth` and/or `maxImageHeight` to constrain rendered
 images while preserving their aspect ratio.
 
-## Events
-
-The component dispatches `data`, `title`, `resize`, `ready`, and `error` events
-for Svelte's legacy `on:event` syntax:
-
-```svelte
-<Terminal on:title={(event) => (document.title = event.detail)} />
-```
-
-The `resize` event's `event.detail` is a `[cols, rows]` tuple. Svelte 5
-applications should generally use the typed callback props instead.
-
 ## Imperative Control
 
 Bind the component instance to call `write`, `resize`, and `focus`:

--- a/apps/docs/src/app/svelte/page.mdx
+++ b/apps/docs/src/app/svelte/page.mdx
@@ -1,0 +1,119 @@
+# Svelte
+
+The `@wterm/svelte` package provides a `<Terminal>` component for Svelte 5
+applications. It re-exports the DOM and core APIs from `@wterm/dom` so the
+component and terminal types can come from one import.
+
+## Install
+
+```bash
+npm install @wterm/dom @wterm/svelte svelte
+```
+
+## Basic Usage
+
+```svelte
+<script lang="ts">
+import { Terminal } from "@wterm/svelte";
+import "@wterm/svelte/css";
+</script>
+
+<Terminal />
+```
+
+The WASM binary is embedded in the package — no extra setup is required. To
+serve it separately, pass `wasmUrl`.
+
+## Custom Input Handling
+
+Typed input is echoed back by default. In Svelte 5, pass `onData` when input
+should be sent to a PTY or another backend:
+
+```svelte
+<script lang="ts">
+import { Terminal } from "@wterm/svelte";
+import "@wterm/svelte/css";
+
+function onData(data: string) {
+  socket.send(data);
+}
+</script>
+
+<Terminal {onData} />
+```
+
+The other callback props are `onTitle`, `onResize`, `onReady`, and `onError`.
+`onReady` receives the underlying `WTerm` instance.
+
+## Props
+
+The component accepts the shared terminal options `cols`, `rows`, `core`,
+`wasmUrl`, `autoResize`, `maxImageWidth`, `maxImageHeight`, `cursorBlink`, and
+`debug`, plus the `theme` prop. Standard `<div>` attributes such as `class`,
+`style`, `id`, and ARIA attributes are forwarded to the root element.
+
+See the [Terminal Options](/api-reference#terminal-options) and
+[Svelte-only Props](/api-reference#svelte-only-props) reference sections for
+details.
+
+The Svelte wrapper delegates rendering to `@wterm/dom`, so a graphics-capable
+core such as `@wterm/ghostty` automatically renders direct Kitty PNG/RGB/RGBA
+images. Set `maxImageWidth` and/or `maxImageHeight` to constrain rendered
+images while preserving their aspect ratio.
+
+## Events
+
+The component dispatches `data`, `title`, `resize`, `ready`, and `error` events
+for Svelte's legacy `on:event` syntax:
+
+```svelte
+<Terminal on:title={(event) => (document.title = event.detail)} />
+```
+
+The `resize` event's `event.detail` is a `[cols, rows]` tuple. Svelte 5
+applications should generally use the typed callback props instead.
+
+## Imperative Control
+
+Bind the component instance to call `write`, `resize`, and `focus`:
+
+```svelte
+<script lang="ts">
+import { Terminal, type TerminalHandle } from "@wterm/svelte";
+
+let terminal: TerminalHandle;
+</script>
+
+<Terminal bind:this={terminal} />
+```
+
+To access the underlying `WTerm`, bind the `instance` prop:
+
+```svelte
+<script lang="ts">
+import { Terminal, type WTerm } from "@wterm/svelte";
+
+let instance: WTerm | null = null;
+</script>
+
+<Terminal bind:instance />
+```
+
+## Themes
+
+Import the stylesheet and pass the theme name:
+
+```svelte
+<script lang="ts">
+import { Terminal } from "@wterm/svelte";
+import "@wterm/svelte/css";
+</script>
+
+<Terminal theme="monokai" />
+```
+
+Built-in themes are `solarized-dark`, `monokai`, and `light`. Define custom
+themes with CSS custom properties.
+
+The component initializes in `onMount`, so it is safe to render from an SSR
+application.

--- a/apps/docs/src/app/themes/page.mdx
+++ b/apps/docs/src/app/themes/page.mdx
@@ -20,6 +20,14 @@ Same `theme` prop:
 <Terminal theme="monokai" />
 ```
 
+### Svelte
+
+Pass the theme name through the `theme` prop:
+
+```svelte
+<Terminal theme="monokai" />
+```
+
 ### Vanilla JS
 
 Add the theme class to the terminal element:

--- a/apps/docs/src/lib/docs-navigation.ts
+++ b/apps/docs/src/lib/docs-navigation.ts
@@ -27,6 +27,7 @@ export const navGroups: NavGroup[] = [
     items: [
       { name: "React", href: "/react" },
       { name: "Vue", href: "/vue" },
+      { name: "Svelte", href: "/svelte" },
       { name: "Vanilla JS", href: "/vanilla" },
     ],
   },
@@ -95,6 +96,11 @@ export const navGroups: NavGroup[] = [
       {
         name: "@wterm/vue",
         href: `${GITHUB}/tree/main/packages/@wterm/vue`,
+        external: true,
+      },
+      {
+        name: "@wterm/svelte",
+        href: `${GITHUB}/tree/main/packages/@wterm/svelte`,
         external: true,
       },
       {

--- a/apps/docs/src/lib/page-titles.ts
+++ b/apps/docs/src/lib/page-titles.ts
@@ -6,6 +6,7 @@ export const PAGE_TITLES: Record<string, string> = {
   themes: "Themes",
   react: "React",
   vue: "Vue",
+  svelte: "Svelte",
   vanilla: "Vanilla JS",
   ghostty: "Ghostty Core",
   "just-bash": "Just Bash",

--- a/examples/svelte/README.md
+++ b/examples/svelte/README.md
@@ -1,0 +1,37 @@
+# Svelte Example
+
+In-browser terminal running [just-bash](https://github.com/vercel-labs/just-bash)
+through the `@wterm/svelte` component. It demonstrates Svelte 5 callback props,
+imperative component methods, theme switching, and browser-native terminal
+selection.
+
+## Setup
+
+From the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter svelte-example dev
+```
+
+Opens at `svelte-example.wterm.localhost` via
+[portless](https://github.com/vercel-labs/portless).
+
+## How It Works
+
+- `@wterm/svelte` owns the terminal lifecycle and forwards input through `onData`
+- `@wterm/just-bash` runs the shell entirely in the browser
+- Svelte callback props handle readiness, input, and title updates
+- The theme selector updates the component's `theme` prop without remounting it
+- Virtual files (`README.md`, `hello.sh`) are preloaded into the shell
+
+## Key Files
+
+| File | Description |
+|---|---|
+| `src/App.svelte` | Terminal UI, shell setup, callbacks, controls, and theme picker |
+| `src/main.ts` | Mounts the Svelte app and imports global styles |
+| `src/style.css` | Example page and control styling |
+| `vite.config.ts` | Svelte plugin and Portless host configuration |
+| `svelte.config.js` | Svelte compiler configuration |
+| `index.html` | HTML shell |

--- a/examples/svelte/index.html
+++ b/examples/svelte/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>wterm — Svelte Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "svelte-example",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "predev": "command -v portless >/dev/null 2>&1 || (echo '\\nportless is required but not installed. Run: npm i -g portless\\nSee: https://github.com/vercel-labs/portless\\n' && exit 1)",
+    "dev": "portless svelte-example.wterm vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "type-check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "dependencies": {
+    "@wterm/dom": "workspace:*",
+    "@wterm/just-bash": "workspace:*",
+    "@wterm/svelte": "workspace:*",
+    "just-bash": "^2.14.2"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
+    "svelte": "^5.57.0",
+    "svelte-check": "^4.7.6",
+    "typescript": "^6.0.2",
+    "vite": "^8.2.2"
+  }
+}

--- a/examples/svelte/src/App.svelte
+++ b/examples/svelte/src/App.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { BashShell } from "@wterm/just-bash";
+  import {
+    Terminal,
+    type TerminalHandle,
+    type WTerm,
+  } from "@wterm/svelte";
+  import "@wterm/svelte/css";
+
+  const themes = [
+    { label: "Default", value: undefined },
+    { label: "Solarized Dark", value: "solarized-dark" },
+    { label: "Monokai", value: "monokai" },
+    { label: "Light", value: "light" },
+  ];
+
+  const files: Record<string, string> = {
+    "/home/user/README.md":
+      "# wterm\n\nA terminal emulator for the web, powered by Svelte and WebAssembly.\n",
+    "/home/user/hello.sh":
+      '#!/bin/bash\necho "Hello from the Svelte example!"\n',
+  };
+
+  let terminal: TerminalHandle | undefined;
+  let shell: BashShell | undefined;
+  let theme: string | undefined;
+  let title = "wterm — Svelte Example";
+
+  function handleReady(wt: WTerm): void {
+    if (shell) return;
+
+    const nextShell = new BashShell({
+      files,
+      greeting: [
+        "wterm — Svelte 5 example",
+        "Powered by @wterm/svelte and just-bash",
+        "",
+        "Try: ls, cat README.md, or bash hello.sh",
+        "",
+      ],
+    });
+
+    shell = nextShell;
+    nextShell.attach(wt.write.bind(wt));
+  }
+
+  function handleData(data: string): void {
+    shell?.handleInput(data);
+  }
+
+  function handleTitle(nextTitle: string): void {
+    title = nextTitle;
+    document.title = nextTitle;
+  }
+
+  function runCommand(command: string): void {
+    shell?.handleInput(`${command}\r`);
+  }
+</script>
+
+<svelte:head>
+  <title>{title}</title>
+</svelte:head>
+
+<div class="page">
+  <header class="header">
+    <div>
+      <p class="eyebrow">wterm playground</p>
+      <h1>{title}</h1>
+    </div>
+
+    <label>
+      <span>Theme</span>
+      <select bind:value={theme}>
+        {#each themes as option}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </select>
+    </label>
+  </header>
+
+  <main>
+    <Terminal
+      bind:this={terminal}
+      {theme}
+      cols={88}
+      rows={28}
+      className="terminal"
+      onData={handleData}
+      onReady={handleReady}
+      onTitle={handleTitle}
+    />
+
+    <div class="controls">
+      <button type="button" onclick={() => runCommand("help")}>Run help</button>
+      <button type="button" onclick={() => runCommand("ls")}>List files</button>
+      <button type="button" onclick={() => terminal?.focus()}>Focus terminal</button>
+    </div>
+  </main>
+
+  <p class="hint">
+    Input is handled by <code>@wterm/just-bash</code> in the browser. Select text,
+    copy it, or try <code>cat README.md</code>.
+  </p>
+</div>

--- a/examples/svelte/src/main.ts
+++ b/examples/svelte/src/main.ts
@@ -1,0 +1,7 @@
+import { mount } from "svelte";
+import App from "./App.svelte";
+import "./style.css";
+
+mount(App, {
+  target: document.getElementById("app")!,
+});

--- a/examples/svelte/src/style.css
+++ b/examples/svelte/src/style.css
@@ -1,0 +1,117 @@
+:root {
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  color: #f5f5f5;
+  background: #101018;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+}
+
+button,
+select {
+  font: inherit;
+}
+
+button,
+select {
+  border: 1px solid #3b3b50;
+  border-radius: 0.5rem;
+  color: #f5f5f5;
+  background: #1c1c2a;
+}
+
+button {
+  cursor: pointer;
+  padding: 0.55rem 0.8rem;
+}
+
+button:hover {
+  border-color: #8585ff;
+}
+
+select {
+  padding: 0.5rem 0.7rem;
+}
+
+.page {
+  width: min(1100px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  color: #9b9bb5;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  letter-spacing: -0.03em;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  color: #b5b5ca;
+  font-size: 0.8rem;
+}
+
+main {
+  display: grid;
+  gap: 1rem;
+}
+
+.terminal {
+  width: 100%;
+  min-height: 28rem;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.hint {
+  margin: 1rem 0 0;
+  color: #9b9bb5;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+code {
+  color: #c7c7ff;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+@media (max-width: 640px) {
+  .header {
+    align-items: start;
+    flex-direction: column;
+  }
+}

--- a/examples/svelte/svelte.config.js
+++ b/examples/svelte/svelte.config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/examples/svelte/tsconfig.json
+++ b/examples/svelte/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"]
+  },
+  "include": ["src", "*.d.ts", "vite.config.ts"]
+}

--- a/examples/svelte/vite.config.ts
+++ b/examples/svelte/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+
+export default defineConfig({
+  plugins: [svelte()],
+  server: {
+    allowedHosts: ["svelte-example.wterm.localhost"],
+  },
+});

--- a/examples/svelte/wterm-svelte.d.ts
+++ b/examples/svelte/wterm-svelte.d.ts
@@ -1,0 +1,1 @@
+declare module "@wterm/svelte/css";

--- a/packages/@wterm/core/README.md
+++ b/packages/@wterm/core/README.md
@@ -9,6 +9,7 @@ Headless terminal emulator core for [wterm](https://github.com/vercel-labs/wterm
 | [`@wterm/dom`](https://www.npmjs.com/package/@wterm/dom) | DOM renderer, input handler — vanilla JS terminal |
 | [`@wterm/react`](https://www.npmjs.com/package/@wterm/react) | React component + `useTerminal` hook |
 | [`@wterm/vue`](https://www.npmjs.com/package/@wterm/vue) | Vue 3 component + template ref API |
+| [`@wterm/svelte`](https://www.npmjs.com/package/@wterm/svelte) | Svelte component + callback/event API |
 | [`@wterm/ghostty`](https://www.npmjs.com/package/@wterm/ghostty) | Full-featured VT emulation core powered by libghostty |
 | [`@wterm/just-bash`](https://www.npmjs.com/package/@wterm/just-bash) | In-browser Bash shell powered by just-bash |
 | [`@wterm/markdown`](https://www.npmjs.com/package/@wterm/markdown) | Streaming Markdown-to-ANSI renderer for terminals |

--- a/packages/@wterm/core/README.md
+++ b/packages/@wterm/core/README.md
@@ -9,7 +9,7 @@ Headless terminal emulator core for [wterm](https://github.com/vercel-labs/wterm
 | [`@wterm/dom`](https://www.npmjs.com/package/@wterm/dom) | DOM renderer, input handler — vanilla JS terminal |
 | [`@wterm/react`](https://www.npmjs.com/package/@wterm/react) | React component + `useTerminal` hook |
 | [`@wterm/vue`](https://www.npmjs.com/package/@wterm/vue) | Vue 3 component + template ref API |
-| [`@wterm/svelte`](https://www.npmjs.com/package/@wterm/svelte) | Svelte component + callback/event API |
+| [`@wterm/svelte`](https://www.npmjs.com/package/@wterm/svelte) | Svelte component + callback API |
 | [`@wterm/ghostty`](https://www.npmjs.com/package/@wterm/ghostty) | Full-featured VT emulation core powered by libghostty |
 | [`@wterm/just-bash`](https://www.npmjs.com/package/@wterm/just-bash) | In-browser Bash shell powered by just-bash |
 | [`@wterm/markdown`](https://www.npmjs.com/package/@wterm/markdown) | Streaming Markdown-to-ANSI renderer for terminals |

--- a/packages/@wterm/ghostty/README.md
+++ b/packages/@wterm/ghostty/README.md
@@ -70,6 +70,19 @@ const core = await GhosttyCore.load();
 </template>
 ```
 
+### Svelte
+
+```svelte
+<script lang="ts">
+import { Terminal } from "@wterm/svelte";
+import { GhosttyCore } from "@wterm/ghostty";
+
+const core = await GhosttyCore.load();
+</script>
+
+<Terminal {core} />
+```
+
 ## Options
 
 `GhosttyCore.load()` accepts an options object:

--- a/packages/@wterm/ghostty/README.md
+++ b/packages/@wterm/ghostty/README.md
@@ -74,13 +74,22 @@ const core = await GhosttyCore.load();
 
 ```svelte
 <script lang="ts">
+import { onMount } from "svelte";
 import { Terminal } from "@wterm/svelte";
 import { GhosttyCore } from "@wterm/ghostty";
 
-const core = await GhosttyCore.load();
+let core: GhosttyCore | undefined;
+
+onMount(() => {
+  void GhosttyCore.load().then((loaded) => {
+    core = loaded;
+  });
+});
 </script>
 
-<Terminal {core} />
+{#if core}
+  <Terminal {core} />
+{/if}
 ```
 
 ## Options

--- a/packages/@wterm/svelte/README.md
+++ b/packages/@wterm/svelte/README.md
@@ -62,17 +62,6 @@ core such as `@wterm/ghostty` renders direct Kitty PNG/RGB/RGBA images. Use
 `maxImageWidth` and/or `maxImageHeight` to constrain oversized images while
 preserving their aspect ratio.
 
-## Events
-
-The component dispatches typed `data`, `title`, `resize`, `ready`, and `error`
-events for Svelte's legacy `on:event` syntax. The `resize` event carries a
-`[cols, rows]` tuple in `event.detail`; the other events carry their value
-directly. Svelte 5 applications can use the callback props above instead.
-
-```svelte
-<Terminal on:title={(event) => (document.title = event.detail)} />
-```
-
 ## Imperative control
 
 Bind the component instance to call `write`, `resize`, and `focus`:

--- a/packages/@wterm/svelte/README.md
+++ b/packages/@wterm/svelte/README.md
@@ -1,0 +1,123 @@
+# @wterm/svelte
+
+Svelte component for [wterm](https://github.com/vercel-labs/wterm) — a terminal emulator for the web.
+
+## Install
+
+```bash
+npm install @wterm/dom @wterm/svelte svelte
+```
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { Terminal } from "@wterm/svelte";
+  import "@wterm/svelte/css";
+</script>
+
+<Terminal />
+```
+
+The WASM binary is embedded in the package. Pass `wasmUrl` to serve it as a
+separate static asset instead.
+
+By default, typed input is echoed back to the terminal. Use the callback props
+when input needs to be sent to a PTY or another backend:
+
+```svelte
+<script lang="ts">
+  import { Terminal } from "@wterm/svelte";
+  import "@wterm/svelte/css";
+
+  function onData(data: string) {
+    socket.send(data);
+  }
+</script>
+
+<Terminal {onData} />
+```
+
+## Props
+
+The terminal accepts the shared `WTerm` options `cols`, `rows`, `core`,
+`wasmUrl`, `autoResize`, `maxImageWidth`, `maxImageHeight`, `cursorBlink`, and
+`debug`, plus these Svelte callbacks:
+
+| Prop       | Type                                   | Default | Description                                                                               |
+| ---------- | -------------------------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| `theme`    | `string`                               | —       | Theme name, such as `"solarized-dark"`, `"monokai"`, or `"light"`                         |
+| `onData`   | `(data: string) => void`               | —       | Called for terminal input and host responses; when omitted, input is echoed automatically |
+| `onTitle`  | `(title: string) => void`              | —       | Called when the terminal title changes                                                    |
+| `onResize` | `(cols: number, rows: number) => void` | —       | Called after the terminal is resized                                                      |
+| `onReady`  | `(wt: WTerm) => void`                  | —       | Called after initialization completes                                                     |
+| `onError`  | `(error: unknown) => void`             | —       | Called if WASM loading or initialization fails                                            |
+
+Standard `<div>` attributes, including `class`, `style`, `id`, and ARIA
+attributes, are forwarded to the root element. `className` is also accepted as
+a convenience for code shared with React.
+
+The component delegates rendering to `@wterm/dom`, so passing a graphics-capable
+core such as `@wterm/ghostty` renders direct Kitty PNG/RGB/RGBA images. Use
+`maxImageWidth` and/or `maxImageHeight` to constrain oversized images while
+preserving their aspect ratio.
+
+## Events
+
+The component dispatches typed `data`, `title`, `resize`, `ready`, and `error`
+events for Svelte's legacy `on:event` syntax. The `resize` event carries a
+`[cols, rows]` tuple in `event.detail`; the other events carry their value
+directly. Svelte 5 applications can use the callback props above instead.
+
+```svelte
+<Terminal on:title={(event) => (document.title = event.detail)} />
+```
+
+## Imperative control
+
+Bind the component instance to call `write`, `resize`, and `focus`:
+
+```svelte
+<script lang="ts">
+  import { Terminal, type TerminalHandle } from "@wterm/svelte";
+
+  let terminal: TerminalHandle;
+</script>
+
+<Terminal bind:this={terminal} />
+
+<button onclick={() => terminal?.write("hello\r\n")}>Write</button>
+<button onclick={() => terminal?.focus()}>Focus</button>
+```
+
+To access the underlying `WTerm`, bind the `instance` prop:
+
+```svelte
+<script lang="ts">
+  import { Terminal, type WTerm } from "@wterm/svelte";
+
+  let instance: WTerm | null = null;
+</script>
+
+<Terminal bind:instance />
+```
+
+## Themes
+
+Import the stylesheet and switch themes with the `theme` prop:
+
+```svelte
+<script lang="ts">
+  import { Terminal } from "@wterm/svelte";
+  import "@wterm/svelte/css";
+</script>
+
+<Terminal theme="monokai" />
+```
+
+Built-in themes: `solarized-dark`, `monokai`, and `light`. Define custom themes
+with CSS custom properties.
+
+## License
+
+Apache-2.0

--- a/packages/@wterm/svelte/package.json
+++ b/packages/@wterm/svelte/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@wterm/svelte",
+  "version": "0.4.1",
+  "description": "Svelte component for wterm — a terminal emulator for the web",
+  "type": "module",
+  "svelte": "./dist/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./css": {
+      "style": "./src/terminal.css",
+      "import": "./src/terminal.css",
+      "default": "./src/terminal.css"
+    }
+  },
+  "files": [
+    "dist",
+    "src/terminal.css"
+  ],
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "prepublishOnly": "pnpm build",
+    "test": "vitest run",
+    "type-check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "keywords": [
+    "terminal",
+    "emulator",
+    "wasm",
+    "zig",
+    "svelte",
+    "xterm"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://wterm.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel-labs/wterm",
+    "directory": "packages/@wterm/svelte"
+  },
+  "devDependencies": {
+    "@internal/ts": "workspace:*",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
+    "@testing-library/svelte": "^5.4.2",
+    "@wterm/dom": "workspace:*",
+    "jsdom": "^29.0.2",
+    "svelte": "^5.57.0",
+    "svelte-check": "^4.7.6",
+    "typescript": "~6.0.2",
+    "vitest": "^4.1.11"
+  },
+  "peerDependencies": {
+    "@wterm/dom": "workspace:*",
+    "svelte": "^5.57.0"
+  }
+}

--- a/packages/@wterm/svelte/scripts/build.mjs
+++ b/packages/@wterm/svelte/scripts/build.mjs
@@ -1,0 +1,13 @@
+import { cp, mkdir, rm } from "node:fs/promises";
+
+await rm("dist", { force: true, recursive: true });
+await mkdir("dist", { recursive: true });
+
+await Promise.all([
+  cp("src/lib/index.js", "dist/index.js"),
+  cp("src/lib/index.d.ts", "dist/index.d.ts"),
+  cp("src/lib/Terminal.svelte", "dist/Terminal.svelte"),
+  cp("src/lib/Terminal.svelte.d.ts", "dist/Terminal.svelte.d.ts"),
+]);
+
+console.log("src/lib -> dist");

--- a/packages/@wterm/svelte/src/__tests__/LegacyEvents.svelte
+++ b/packages/@wterm/svelte/src/__tests__/LegacyEvents.svelte
@@ -2,6 +2,7 @@
   import Terminal from "../lib/Terminal.svelte";
 
   export let ondata: (event: CustomEvent<string>) => void;
+  export let rows = 24;
 </script>
 
-<Terminal on:data={ondata} />
+<Terminal {rows} on:data={ondata} />

--- a/packages/@wterm/svelte/src/__tests__/LegacyEvents.svelte
+++ b/packages/@wterm/svelte/src/__tests__/LegacyEvents.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import Terminal from "../lib/Terminal.svelte";
+
+  export let ondata: (event: CustomEvent<string>) => void;
+</script>
+
+<Terminal on:data={ondata} />

--- a/packages/@wterm/svelte/src/__tests__/LegacyEvents.svelte
+++ b/packages/@wterm/svelte/src/__tests__/LegacyEvents.svelte
@@ -1,8 +1,0 @@
-<script lang="ts">
-  import Terminal from "../lib/Terminal.svelte";
-
-  export let ondata: (event: CustomEvent<string>) => void;
-  export let rows = 24;
-</script>
-
-<Terminal {rows} on:data={ondata} />

--- a/packages/@wterm/svelte/src/__tests__/Terminal.test.ts
+++ b/packages/@wterm/svelte/src/__tests__/Terminal.test.ts
@@ -1,0 +1,239 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import Terminal from "../lib/Terminal.svelte";
+
+let lastWTermInstance: any = null;
+
+vi.mock("@wterm/dom", () => {
+  const mockWTerm = vi.fn().mockImplementation(function (
+    this: any,
+    element: HTMLElement,
+    options: any,
+  ) {
+    this.element = element;
+    this.bridge = null;
+    this.cols = options?.cols ?? 80;
+    this.rows = options?.rows ?? 24;
+    this.onData = options?.onData ?? null;
+    this.onTitle = options?.onTitle ?? null;
+    this.onResize = options?.onResize ?? null;
+    this.autoResize = options?.autoResize !== false;
+    this.write = vi.fn();
+    this.resize = vi.fn((cols: number, rows: number) => {
+      this.cols = cols;
+      this.rows = rows;
+    });
+    this.focus = vi.fn();
+    this.destroy = vi.fn();
+    this.init = vi.fn().mockImplementation(async () => {
+      this.bridge = {};
+      return this;
+    });
+    lastWTermInstance = this;
+  });
+
+  return {
+    WTerm: mockWTerm,
+    Renderer: vi.fn(),
+    InputHandler: vi.fn(),
+  };
+});
+
+describe("Terminal component", () => {
+  beforeEach(() => {
+    lastWTermInstance = null;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders an accessible terminal element", () => {
+    const { getByRole } = render(Terminal);
+    const element = getByRole("textbox");
+
+    expect(element.getAttribute("aria-label")).toBe("Terminal");
+    expect(element.getAttribute("aria-multiline")).toBe("true");
+    expect(element.getAttribute("aria-roledescription")).toBe("terminal");
+  });
+
+  it("forwards classes and styles", () => {
+    const { getByRole } = render(Terminal, {
+      props: {
+        class: "custom",
+        style: "background: purple",
+        theme: "dark",
+      },
+    });
+    const element = getByRole("textbox");
+
+    expect(element.classList.contains("wterm")).toBe(true);
+    expect(element.classList.contains("custom")).toBe(true);
+    expect(element.classList.contains("theme-dark")).toBe(true);
+    expect(element.style.background).toBe("purple");
+    expect(element.style.height).toBe("432px");
+  });
+
+  it("creates and initializes WTerm on mount", async () => {
+    const { WTerm } = await import("@wterm/dom");
+    render(Terminal);
+    await Promise.resolve();
+
+    expect(WTerm).toHaveBeenCalled();
+    expect(lastWTermInstance.init).toHaveBeenCalled();
+  });
+
+  it("passes terminal options to WTerm", async () => {
+    const { WTerm } = await import("@wterm/dom");
+    render(Terminal, {
+      props: {
+        cols: 120,
+        rows: 40,
+        autoResize: true,
+        maxImageWidth: 800,
+        maxImageHeight: 600,
+        debug: true,
+      },
+    });
+
+    expect(WTerm).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        cols: 120,
+        rows: 40,
+        autoResize: true,
+        maxImageWidth: 800,
+        maxImageHeight: 600,
+        debug: true,
+      }),
+    );
+  });
+
+  it("calls the ready callback", async () => {
+    const onReady = vi.fn();
+    render(Terminal, { props: { onReady } });
+
+    await Promise.resolve();
+
+    expect(onReady).toHaveBeenCalledWith(lastWTermInstance);
+  });
+
+  it("forwards input through onData", async () => {
+    const onData = vi.fn();
+    render(Terminal, { props: { onData } });
+    await Promise.resolve();
+
+    lastWTermInstance.onData("hello");
+
+    expect(onData).toHaveBeenCalledWith("hello");
+  });
+
+  it("exposes imperative methods through bind:this", async () => {
+    const { component } = render(Terminal);
+    await Promise.resolve();
+
+    (component as any).write("test data");
+    (component as any).resize(120, 40);
+    (component as any).focus();
+
+    expect(lastWTermInstance.write).toHaveBeenCalledWith("test data");
+    expect(lastWTermInstance.resize).toHaveBeenCalledWith(120, 40);
+    expect(lastWTermInstance.focus).toHaveBeenCalled();
+  });
+
+  it("exposes imperative methods through bind:this", async () => {
+    const { component } = render(Terminal);
+    await Promise.resolve();
+
+    (component as any).write("test data");
+    (component as any).resize(120, 40);
+    (component as any).focus();
+
+    expect(lastWTermInstance.write).toHaveBeenCalledWith("test data");
+    expect(lastWTermInstance.resize).toHaveBeenCalledWith(120, 40);
+    expect(lastWTermInstance.focus).toHaveBeenCalled();
+  });
+
+  it("supports Svelte 5 callback-style event props", async () => {
+    const ondata = vi.fn();
+    const ontitle = vi.fn();
+    const onresize = vi.fn();
+    render(Terminal, { props: { ondata, ontitle, onresize } });
+    await Promise.resolve();
+
+    lastWTermInstance.onData("hello");
+    lastWTermInstance.onTitle("my title");
+    lastWTermInstance.onResize(100, 30);
+
+    expect(ondata).toHaveBeenCalledWith("hello");
+    expect(ontitle).toHaveBeenCalledWith("my title");
+    expect(onresize).toHaveBeenCalledWith(100, 30);
+  });
+
+  it("forwards title and resize callbacks", async () => {
+    const onTitle = vi.fn();
+    const onResize = vi.fn();
+    render(Terminal, { props: { onTitle, onResize } });
+    await Promise.resolve();
+
+    lastWTermInstance.onTitle("my title");
+    lastWTermInstance.onResize(100, 30);
+
+    expect(onTitle).toHaveBeenCalledWith("my title");
+    expect(onResize).toHaveBeenCalledWith(100, 30);
+  });
+
+  it("syncs dimensions and cursor blinking when props change", async () => {
+    const result = render(Terminal, {
+      props: { cols: 80, rows: 24, cursorBlink: false },
+    });
+    await Promise.resolve();
+
+    await result.rerender({ cols: 120, rows: 40, cursorBlink: true });
+
+    expect(lastWTermInstance.resize).toHaveBeenCalledWith(120, 40);
+    expect(lastWTermInstance.element.classList.contains("cursor-blink")).toBe(
+      true,
+    );
+  });
+
+  it("destroys WTerm on unmount", async () => {
+    const { unmount } = render(Terminal);
+    await Promise.resolve();
+    const instance = lastWTermInstance;
+
+    unmount();
+
+    expect(instance.destroy).toHaveBeenCalled();
+  });
+
+  it("calls the error callback", async () => {
+    const { WTerm } = await import("@wterm/dom");
+    (WTerm as any).mockImplementationOnce(function (
+      this: any,
+      element: HTMLElement,
+    ) {
+      this.element = element;
+      this.bridge = null;
+      this.cols = 80;
+      this.rows = 24;
+      this.onData = null;
+      this.onTitle = null;
+      this.onResize = null;
+      this.write = vi.fn();
+      this.resize = vi.fn();
+      this.focus = vi.fn();
+      this.destroy = vi.fn();
+      this.init = vi.fn().mockRejectedValue(new Error("WASM failed"));
+      lastWTermInstance = this;
+    });
+
+    const onError = vi.fn();
+    render(Terminal, { props: { onError } });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+});

--- a/packages/@wterm/svelte/src/__tests__/Terminal.test.ts
+++ b/packages/@wterm/svelte/src/__tests__/Terminal.test.ts
@@ -1,6 +1,7 @@
 import { cleanup, render } from "@testing-library/svelte";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import Terminal from "../lib/Terminal.svelte";
+import LegacyEvents from "./LegacyEvents.svelte";
 
 let lastWTermInstance: any = null;
 
@@ -142,19 +143,6 @@ describe("Terminal component", () => {
     expect(lastWTermInstance.focus).toHaveBeenCalled();
   });
 
-  it("exposes imperative methods through bind:this", async () => {
-    const { component } = render(Terminal);
-    await Promise.resolve();
-
-    (component as any).write("test data");
-    (component as any).resize(120, 40);
-    (component as any).focus();
-
-    expect(lastWTermInstance.write).toHaveBeenCalledWith("test data");
-    expect(lastWTermInstance.resize).toHaveBeenCalledWith(120, 40);
-    expect(lastWTermInstance.focus).toHaveBeenCalled();
-  });
-
   it("supports Svelte 5 callback-style event props", async () => {
     const ondata = vi.fn();
     const ontitle = vi.fn();
@@ -184,6 +172,19 @@ describe("Terminal component", () => {
     expect(onResize).toHaveBeenCalledWith(100, 30);
   });
 
+  it("dispatches legacy data events without a callback prop", async () => {
+    const onDataEvent = vi.fn();
+    render(LegacyEvents, { props: { ondata: onDataEvent } });
+    await Promise.resolve();
+
+    expect(lastWTermInstance.onData).toBeTypeOf("function");
+    lastWTermInstance.onData("hello");
+
+    expect(onDataEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: "hello" }),
+    );
+  });
+
   it("syncs dimensions and cursor blinking when props change", async () => {
     const result = render(Terminal, {
       props: { cols: 80, rows: 24, cursorBlink: false },
@@ -206,6 +207,65 @@ describe("Terminal component", () => {
     unmount();
 
     expect(instance.destroy).toHaveBeenCalled();
+  });
+
+  it("does not call ready after unmount while initialization is pending", async () => {
+    const { WTerm } = await import("@wterm/dom");
+    let resolveInit!: () => void;
+    const pendingInit = new Promise<void>((resolve) => {
+      resolveInit = resolve;
+    });
+
+    (WTerm as any).mockImplementationOnce(function (
+      this: any,
+      element: HTMLElement,
+      options: any,
+    ) {
+      this.element = element;
+      this.bridge = null;
+      this.cols = options?.cols ?? 80;
+      this.rows = options?.rows ?? 24;
+      this.onData = options?.onData ?? null;
+      this.onTitle = options?.onTitle ?? null;
+      this.onResize = options?.onResize ?? null;
+      this.write = vi.fn();
+      this.resize = vi.fn();
+      this.focus = vi.fn();
+      this.destroy = vi.fn();
+      this.init = vi.fn(() =>
+        pendingInit.then(() => {
+          this.bridge = {};
+          return this;
+        }),
+      );
+      lastWTermInstance = this;
+    });
+
+    const onReady = vi.fn();
+    const { unmount } = render(Terminal, { props: { onReady } });
+    unmount();
+    resolveInit();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  it("allows overriding the default accessibility attributes", () => {
+    const { container } = render(Terminal, {
+      props: {
+        role: "application",
+        "aria-label": "Shell",
+        "aria-multiline": "false",
+        "aria-roledescription": "shell",
+      } as any,
+    });
+    const element = container.querySelector(".wterm")!;
+
+    expect(element.getAttribute("role")).toBe("application");
+    expect(element.getAttribute("aria-label")).toBe("Shell");
+    expect(element.getAttribute("aria-multiline")).toBe("false");
+    expect(element.getAttribute("aria-roledescription")).toBe("shell");
   });
 
   it("calls the error callback", async () => {

--- a/packages/@wterm/svelte/src/__tests__/Terminal.test.ts
+++ b/packages/@wterm/svelte/src/__tests__/Terminal.test.ts
@@ -185,6 +185,22 @@ describe("Terminal component", () => {
     );
   });
 
+  it("keeps legacy data events wired after reactive updates", async () => {
+    const onDataEvent = vi.fn();
+    const result = render(LegacyEvents, {
+      props: { ondata: onDataEvent, rows: 24 },
+    });
+    await Promise.resolve();
+
+    await result.rerender({ ondata: onDataEvent, rows: 25 });
+
+    expect(lastWTermInstance.onData).toBeTypeOf("function");
+    lastWTermInstance.onData("hello");
+    expect(onDataEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: "hello" }),
+    );
+  });
+
   it("syncs dimensions and cursor blinking when props change", async () => {
     const result = render(Terminal, {
       props: { cols: 80, rows: 24, cursorBlink: false },

--- a/packages/@wterm/svelte/src/__tests__/Terminal.test.ts
+++ b/packages/@wterm/svelte/src/__tests__/Terminal.test.ts
@@ -1,7 +1,7 @@
 import { cleanup, render } from "@testing-library/svelte";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { tick } from "svelte";
 import Terminal from "../lib/Terminal.svelte";
-import LegacyEvents from "./LegacyEvents.svelte";
 
 let lastWTermInstance: any = null;
 
@@ -80,6 +80,7 @@ describe("Terminal component", () => {
     const { WTerm } = await import("@wterm/dom");
     render(Terminal);
     await Promise.resolve();
+    await tick();
 
     expect(WTerm).toHaveBeenCalled();
     expect(lastWTermInstance.init).toHaveBeenCalled();
@@ -130,6 +131,70 @@ describe("Terminal component", () => {
     expect(onData).toHaveBeenCalledWith("hello");
   });
 
+  it("updates the WTerm input handler when onData changes", async () => {
+    const result = render(Terminal);
+    await Promise.resolve();
+
+    expect(lastWTermInstance.onData).toBeNull();
+
+    const onData = vi.fn();
+    await result.rerender({ onData });
+
+    expect(lastWTermInstance.onData).toBeTypeOf("function");
+    lastWTermInstance.onData("hello");
+    expect(onData).toHaveBeenCalledWith("hello");
+
+    await result.rerender({ onData: undefined });
+    expect(lastWTermInstance.onData).toBeNull();
+  });
+
+  it("applies callback changes made while initialization is pending", async () => {
+    const { WTerm } = await import("@wterm/dom");
+    let resolveInit!: () => void;
+    const pendingInit = new Promise<void>((resolve) => {
+      resolveInit = resolve;
+    });
+
+    (WTerm as any).mockImplementationOnce(function (
+      this: any,
+      element: HTMLElement,
+      options: any,
+    ) {
+      this.element = element;
+      this.bridge = null;
+      this.cols = options?.cols ?? 80;
+      this.rows = options?.rows ?? 24;
+      this.onData = options?.onData ?? null;
+      this.onTitle = options?.onTitle ?? null;
+      this.onResize = options?.onResize ?? null;
+      this.write = vi.fn();
+      this.resize = vi.fn();
+      this.focus = vi.fn();
+      this.destroy = vi.fn();
+      this.init = vi.fn(() =>
+        pendingInit.then(() => {
+          this.bridge = {};
+          return this;
+        }),
+      );
+      lastWTermInstance = this;
+    });
+
+    const result = render(Terminal);
+    const onData = vi.fn();
+    await result.rerender({ onData });
+
+    expect(lastWTermInstance.onData).toBeNull();
+    resolveInit();
+    await Promise.resolve();
+    await Promise.resolve();
+    await tick();
+
+    expect(lastWTermInstance.onData).toBeTypeOf("function");
+    lastWTermInstance.onData("hello");
+    expect(onData).toHaveBeenCalledWith("hello");
+  });
+
   it("exposes imperative methods through bind:this", async () => {
     const { component } = render(Terminal);
     await Promise.resolve();
@@ -170,35 +235,6 @@ describe("Terminal component", () => {
 
     expect(onTitle).toHaveBeenCalledWith("my title");
     expect(onResize).toHaveBeenCalledWith(100, 30);
-  });
-
-  it("dispatches legacy data events without a callback prop", async () => {
-    const onDataEvent = vi.fn();
-    render(LegacyEvents, { props: { ondata: onDataEvent } });
-    await Promise.resolve();
-
-    expect(lastWTermInstance.onData).toBeTypeOf("function");
-    lastWTermInstance.onData("hello");
-
-    expect(onDataEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ detail: "hello" }),
-    );
-  });
-
-  it("keeps legacy data events wired after reactive updates", async () => {
-    const onDataEvent = vi.fn();
-    const result = render(LegacyEvents, {
-      props: { ondata: onDataEvent, rows: 24 },
-    });
-    await Promise.resolve();
-
-    await result.rerender({ ondata: onDataEvent, rows: 25 });
-
-    expect(lastWTermInstance.onData).toBeTypeOf("function");
-    lastWTermInstance.onData("hello");
-    expect(onDataEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ detail: "hello" }),
-    );
   });
 
   it("syncs dimensions and cursor blinking when props change", async () => {

--- a/packages/@wterm/svelte/src/__tests__/Terminal.types.test.ts
+++ b/packages/@wterm/svelte/src/__tests__/Terminal.types.test.ts
@@ -1,0 +1,28 @@
+import { expectTypeOf, describe, it } from "vitest";
+import type {
+  TerminalEvents,
+  TerminalHandle,
+  TerminalProps,
+} from "../lib/Terminal.svelte";
+import type { WTerm } from "@wterm/dom";
+
+describe("Terminal types", () => {
+  it("exposes typed props, events, and imperative methods", () => {
+    expectTypeOf<TerminalProps["cols"]>().toEqualTypeOf<number | undefined>();
+    expectTypeOf<TerminalProps["rows"]>().toEqualTypeOf<number | undefined>();
+    expectTypeOf<TerminalProps["theme"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<TerminalProps["onData"]>().toEqualTypeOf<
+      ((data: string) => void) | undefined
+    >();
+    expectTypeOf<TerminalEvents["data"]>().toEqualTypeOf<string>();
+    expectTypeOf<TerminalEvents["resize"]>().toEqualTypeOf<
+      [cols: number, rows: number]
+    >();
+    expectTypeOf<TerminalEvents["ready"]>().toEqualTypeOf<WTerm>();
+    expectTypeOf<TerminalHandle>().toExtend<{
+      write(data: string | Uint8Array): void;
+      resize(cols: number, rows: number): void;
+      focus(): void;
+    }>();
+  });
+});

--- a/packages/@wterm/svelte/src/__tests__/Terminal.types.test.ts
+++ b/packages/@wterm/svelte/src/__tests__/Terminal.types.test.ts
@@ -1,24 +1,18 @@
 import { expectTypeOf, describe, it } from "vitest";
-import type {
-  TerminalEvents,
-  TerminalHandle,
-  TerminalProps,
-} from "../lib/Terminal.svelte";
+import type { TerminalHandle, TerminalProps } from "../lib/Terminal.svelte";
 import type { WTerm } from "@wterm/dom";
 
 describe("Terminal types", () => {
-  it("exposes typed props, events, and imperative methods", () => {
+  it("exposes typed props, callbacks, and imperative methods", () => {
     expectTypeOf<TerminalProps["cols"]>().toEqualTypeOf<number | undefined>();
     expectTypeOf<TerminalProps["rows"]>().toEqualTypeOf<number | undefined>();
     expectTypeOf<TerminalProps["theme"]>().toEqualTypeOf<string | undefined>();
     expectTypeOf<TerminalProps["onData"]>().toEqualTypeOf<
       ((data: string) => void) | undefined
     >();
-    expectTypeOf<TerminalEvents["data"]>().toEqualTypeOf<string>();
-    expectTypeOf<TerminalEvents["resize"]>().toEqualTypeOf<
-      [cols: number, rows: number]
+    expectTypeOf<TerminalProps["onReady"]>().toEqualTypeOf<
+      ((wt: WTerm) => void) | undefined
     >();
-    expectTypeOf<TerminalEvents["ready"]>().toEqualTypeOf<WTerm>();
     expectTypeOf<TerminalHandle>().toExtend<{
       write(data: string | Uint8Array): void;
       resize(cols: number, rows: number): void;

--- a/packages/@wterm/svelte/src/lib/Terminal.svelte
+++ b/packages/@wterm/svelte/src/lib/Terminal.svelte
@@ -77,6 +77,7 @@
   let element: HTMLDivElement;
   export let instance: WTerm | null = null;
   let legacyDataListener = false;
+  let legacyProps: Record<string, unknown> | undefined;
 
   $: classes = [
     "wterm",
@@ -112,13 +113,17 @@
   }
 
   function hasLegacyDataListener(): boolean {
-    const props = (active_effect as any)?.ctx?.s as
-      | Record<string, unknown>
-      | undefined;
-    const events = props?.["$$events"] as
-      | Record<string, unknown>
-      | undefined;
-    return Boolean(events?.data);
+    const props =
+      legacyProps ??
+      ((active_effect as any)?.ctx?.s as
+        | Record<string, unknown>
+        | undefined);
+    legacyProps ??= props;
+    const events = props?.["$$events"] as Record<string, unknown> | undefined;
+    const dataHandlers = events?.data;
+    return Array.isArray(dataHandlers)
+      ? dataHandlers.length > 0
+      : Boolean(dataHandlers);
   }
 
   function hasDataHandler(): boolean {
@@ -182,6 +187,7 @@
   // Keep the small set of mutable options that WTerm supports in sync with
   // the component. Core, WASM source, and image sizing are init-time options.
   $: if (instance?.bridge) {
+    legacyDataListener = hasLegacyDataListener();
     if (!autoResize && (instance.cols !== cols || instance.rows !== rows)) {
       instance.resize(cols, rows);
     }

--- a/packages/@wterm/svelte/src/lib/Terminal.svelte
+++ b/packages/@wterm/svelte/src/lib/Terminal.svelte
@@ -42,6 +42,10 @@
 
 <script lang="ts">
   import { createEventDispatcher, onMount } from "svelte";
+  // Svelte does not expose the legacy component event map through its public
+  // API. The event dispatcher stores it on the current legacy effect context.
+  // @ts-ignore -- svelte/internal/client intentionally has no public types.
+  import { active_effect } from "svelte/internal/client";
   import { WTerm, type TerminalCore } from "@wterm/dom";
 
   const dispatch = createEventDispatcher<TerminalEvents>();
@@ -72,6 +76,7 @@
 
   let element: HTMLDivElement;
   export let instance: WTerm | null = null;
+  let legacyDataListener = false;
 
   $: classes = [
     "wterm",
@@ -106,6 +111,20 @@
     dispatch("resize", [nextCols, nextRows]);
   }
 
+  function hasLegacyDataListener(): boolean {
+    const props = (active_effect as any)?.ctx?.s as
+      | Record<string, unknown>
+      | undefined;
+    const events = props?.["$$events"] as
+      | Record<string, unknown>
+      | undefined;
+    return Boolean(events?.data);
+  }
+
+  function hasDataHandler(): boolean {
+    return Boolean(onData || ondata || legacyDataListener);
+  }
+
   export function write(data: string | Uint8Array): void {
     instance?.write(data);
   }
@@ -119,6 +138,8 @@
   }
 
   onMount(() => {
+    let disposed = false;
+    legacyDataListener = hasLegacyDataListener();
     const wt = new WTerm(element, {
       cols,
       rows,
@@ -129,7 +150,7 @@
       maxImageHeight,
       cursorBlink,
       debug,
-      onData: onData || ondata ? handleData : undefined,
+      onData: hasDataHandler() ? handleData : undefined,
       onTitle: handleTitle,
       onResize: handleResize,
     });
@@ -138,11 +159,13 @@
 
     wt.init()
       .then(() => {
+        if (disposed) return;
         onReady?.(wt);
         onready?.(wt);
         dispatch("ready", wt);
       })
       .catch((error: unknown) => {
+        if (disposed) return;
         onError?.(error);
         onerror?.(error);
         dispatch("error", error);
@@ -150,6 +173,7 @@
       });
 
     return () => {
+      disposed = true;
       wt.destroy();
       if (instance === wt) instance = null;
     };
@@ -162,7 +186,7 @@
       instance.resize(cols, rows);
     }
     instance.element.classList.toggle("cursor-blink", cursorBlink);
-    instance.onData = onData || ondata ? handleData : null;
+    instance.onData = hasDataHandler() ? handleData : null;
   }
 </script>
 
@@ -171,8 +195,8 @@
   {...$$restProps}
   class={classes}
   style={mergedStyle || undefined}
-  role="textbox"
-  aria-label="Terminal"
-  aria-multiline="true"
-  aria-roledescription="terminal"
+  role={$$restProps.role ?? "textbox"}
+  aria-label={$$restProps["aria-label"] ?? "Terminal"}
+  aria-multiline={$$restProps["aria-multiline"] ?? "true"}
+  aria-roledescription={$$restProps["aria-roledescription"] ?? "terminal"}
 ></div>

--- a/packages/@wterm/svelte/src/lib/Terminal.svelte
+++ b/packages/@wterm/svelte/src/lib/Terminal.svelte
@@ -1,16 +1,5 @@
 <script context="module" lang="ts">
-  import type {
-    WTerm as WTermType,
-    WTermOptions,
-  } from "@wterm/dom";
-
-  export interface TerminalEvents {
-    data: string;
-    title: string;
-    resize: [cols: number, rows: number];
-    ready: WTermType;
-    error: unknown;
-  }
+  import type { WTerm as WTermType, WTermOptions } from "@wterm/dom";
 
   export interface TerminalProps
     extends Omit<WTermOptions, "onData" | "onTitle" | "onResize"> {
@@ -41,14 +30,8 @@
 </script>
 
 <script lang="ts">
-  import { createEventDispatcher, onMount } from "svelte";
-  // Svelte does not expose the legacy component event map through its public
-  // API. The event dispatcher stores it on the current legacy effect context.
-  // @ts-ignore -- svelte/internal/client intentionally has no public types.
-  import { active_effect } from "svelte/internal/client";
+  import { onMount } from "svelte";
   import { WTerm, type TerminalCore } from "@wterm/dom";
-
-  const dispatch = createEventDispatcher<TerminalEvents>();
 
   export let cols = 80;
   export let rows = 24;
@@ -76,8 +59,7 @@
 
   let element: HTMLDivElement;
   export let instance: WTerm | null = null;
-  let legacyDataListener = false;
-  let legacyProps: Record<string, unknown> | undefined;
+  let initialized = false;
 
   $: classes = [
     "wterm",
@@ -97,37 +79,20 @@
   function handleData(data: string): void {
     onData?.(data);
     ondata?.(data);
-    dispatch("data", data);
   }
 
   function handleTitle(title: string): void {
     onTitle?.(title);
     ontitle?.(title);
-    dispatch("title", title);
   }
 
   function handleResize(nextCols: number, nextRows: number): void {
     onResize?.(nextCols, nextRows);
     onresize?.(nextCols, nextRows);
-    dispatch("resize", [nextCols, nextRows]);
-  }
-
-  function hasLegacyDataListener(): boolean {
-    const props =
-      legacyProps ??
-      ((active_effect as any)?.ctx?.s as
-        | Record<string, unknown>
-        | undefined);
-    legacyProps ??= props;
-    const events = props?.["$$events"] as Record<string, unknown> | undefined;
-    const dataHandlers = events?.data;
-    return Array.isArray(dataHandlers)
-      ? dataHandlers.length > 0
-      : Boolean(dataHandlers);
   }
 
   function hasDataHandler(): boolean {
-    return Boolean(onData || ondata || legacyDataListener);
+    return Boolean(onData || ondata);
   }
 
   export function write(data: string | Uint8Array): void {
@@ -144,7 +109,6 @@
 
   onMount(() => {
     let disposed = false;
-    legacyDataListener = hasLegacyDataListener();
     const wt = new WTerm(element, {
       cols,
       rows,
@@ -165,15 +129,14 @@
     wt.init()
       .then(() => {
         if (disposed) return;
+        initialized = true;
         onReady?.(wt);
         onready?.(wt);
-        dispatch("ready", wt);
       })
       .catch((error: unknown) => {
         if (disposed) return;
         onError?.(error);
         onerror?.(error);
-        dispatch("error", error);
         if (!onError && !onerror) console.error(error);
       });
 
@@ -186,13 +149,13 @@
 
   // Keep the small set of mutable options that WTerm supports in sync with
   // the component. Core, WASM source, and image sizing are init-time options.
-  $: if (instance?.bridge) {
-    legacyDataListener = hasLegacyDataListener();
+  $: if (initialized && instance?.bridge) {
+    const dataHandler = Boolean(onData || ondata);
     if (!autoResize && (instance.cols !== cols || instance.rows !== rows)) {
       instance.resize(cols, rows);
     }
     instance.element.classList.toggle("cursor-blink", cursorBlink);
-    instance.onData = hasDataHandler() ? handleData : null;
+    instance.onData = dataHandler ? handleData : null;
   }
 </script>
 

--- a/packages/@wterm/svelte/src/lib/Terminal.svelte
+++ b/packages/@wterm/svelte/src/lib/Terminal.svelte
@@ -1,0 +1,178 @@
+<script context="module" lang="ts">
+  import type {
+    WTerm as WTermType,
+    WTermOptions,
+  } from "@wterm/dom";
+
+  export interface TerminalEvents {
+    data: string;
+    title: string;
+    resize: [cols: number, rows: number];
+    ready: WTermType;
+    error: unknown;
+  }
+
+  export interface TerminalProps
+    extends Omit<WTermOptions, "onData" | "onTitle" | "onResize"> {
+    theme?: string;
+    className?: string;
+    onData?: (data: string) => void;
+    onTitle?: (title: string) => void;
+    onResize?: (cols: number, rows: number) => void;
+    onReady?: (wt: WTermType) => void;
+    onError?: (error: unknown) => void;
+    ondata?: (data: string) => void;
+    ontitle?: (title: string) => void;
+    onresize?: (cols: number, rows: number) => void;
+    onready?: (wt: WTermType) => void;
+    onerror?: (error: unknown) => void;
+    class?: string;
+    style?: string;
+    id?: string;
+    instance?: WTermType | null;
+    [key: string]: unknown;
+  }
+
+  export interface TerminalHandle {
+    write(data: string | Uint8Array): void;
+    resize(cols: number, rows: number): void;
+    focus(): void;
+  }
+</script>
+
+<script lang="ts">
+  import { createEventDispatcher, onMount } from "svelte";
+  import { WTerm, type TerminalCore } from "@wterm/dom";
+
+  const dispatch = createEventDispatcher<TerminalEvents>();
+
+  export let cols = 80;
+  export let rows = 24;
+  export let core: TerminalCore | undefined = undefined;
+  export let wasmUrl: string | undefined = undefined;
+  export let theme: string | undefined = undefined;
+  export let autoResize = false;
+  export let maxImageWidth: number | undefined = undefined;
+  export let maxImageHeight: number | undefined = undefined;
+  export let cursorBlink = false;
+  export let debug = false;
+  export let className = "";
+  export let onData: ((data: string) => void) | undefined = undefined;
+  export let onTitle: ((title: string) => void) | undefined = undefined;
+  export let onResize: ((cols: number, rows: number) => void) | undefined =
+    undefined;
+  export let onReady: ((wt: WTerm) => void) | undefined = undefined;
+  export let onError: ((error: unknown) => void) | undefined = undefined;
+  export let ondata: ((data: string) => void) | undefined = undefined;
+  export let ontitle: ((title: string) => void) | undefined = undefined;
+  export let onresize: ((cols: number, rows: number) => void) | undefined =
+    undefined;
+  export let onready: ((wt: WTerm) => void) | undefined = undefined;
+  export let onerror: ((error: unknown) => void) | undefined = undefined;
+
+  let element: HTMLDivElement;
+  export let instance: WTerm | null = null;
+
+  $: classes = [
+    "wterm",
+    theme ? `theme-${theme}` : "",
+    cursorBlink ? "cursor-blink" : "",
+    className,
+    typeof $$restProps.class === "string" ? $$restProps.class : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  $: heightStyle = autoResize ? "" : `height: ${rows * 17 + 24}px`;
+  $: mergedStyle = [heightStyle, $$restProps.style]
+    .filter(Boolean)
+    .join("; ");
+
+  function handleData(data: string): void {
+    onData?.(data);
+    ondata?.(data);
+    dispatch("data", data);
+  }
+
+  function handleTitle(title: string): void {
+    onTitle?.(title);
+    ontitle?.(title);
+    dispatch("title", title);
+  }
+
+  function handleResize(nextCols: number, nextRows: number): void {
+    onResize?.(nextCols, nextRows);
+    onresize?.(nextCols, nextRows);
+    dispatch("resize", [nextCols, nextRows]);
+  }
+
+  export function write(data: string | Uint8Array): void {
+    instance?.write(data);
+  }
+
+  export function resize(nextCols: number, nextRows: number): void {
+    instance?.resize(nextCols, nextRows);
+  }
+
+  export function focus(): void {
+    instance?.focus();
+  }
+
+  onMount(() => {
+    const wt = new WTerm(element, {
+      cols,
+      rows,
+      core,
+      wasmUrl,
+      autoResize,
+      maxImageWidth,
+      maxImageHeight,
+      cursorBlink,
+      debug,
+      onData: onData || ondata ? handleData : undefined,
+      onTitle: handleTitle,
+      onResize: handleResize,
+    });
+
+    instance = wt;
+
+    wt.init()
+      .then(() => {
+        onReady?.(wt);
+        onready?.(wt);
+        dispatch("ready", wt);
+      })
+      .catch((error: unknown) => {
+        onError?.(error);
+        onerror?.(error);
+        dispatch("error", error);
+        if (!onError && !onerror) console.error(error);
+      });
+
+    return () => {
+      wt.destroy();
+      if (instance === wt) instance = null;
+    };
+  });
+
+  // Keep the small set of mutable options that WTerm supports in sync with
+  // the component. Core, WASM source, and image sizing are init-time options.
+  $: if (instance?.bridge) {
+    if (!autoResize && (instance.cols !== cols || instance.rows !== rows)) {
+      instance.resize(cols, rows);
+    }
+    instance.element.classList.toggle("cursor-blink", cursorBlink);
+    instance.onData = onData || ondata ? handleData : null;
+  }
+</script>
+
+<div
+  bind:this={element}
+  {...$$restProps}
+  class={classes}
+  style={mergedStyle || undefined}
+  role="textbox"
+  aria-label="Terminal"
+  aria-multiline="true"
+  aria-roledescription="terminal"
+></div>

--- a/packages/@wterm/svelte/src/lib/Terminal.svelte.d.ts
+++ b/packages/@wterm/svelte/src/lib/Terminal.svelte.d.ts
@@ -1,0 +1,53 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { WTerm, WTermOptions } from "@wterm/dom";
+
+export interface TerminalEvents {
+  data: string;
+  title: string;
+  resize: [cols: number, rows: number];
+  ready: WTerm;
+  error: unknown;
+}
+
+export interface TerminalProps extends Omit<
+  WTermOptions,
+  "onData" | "onTitle" | "onResize"
+> {
+  theme?: string;
+  className?: string;
+  onData?: (data: string) => void;
+  onTitle?: (title: string) => void;
+  onResize?: (cols: number, rows: number) => void;
+  onReady?: (wt: WTerm) => void;
+  onError?: (error: unknown) => void;
+  ondata?: (data: string) => void;
+  ontitle?: (title: string) => void;
+  onresize?: (cols: number, rows: number) => void;
+  onready?: (wt: WTerm) => void;
+  onerror?: (error: unknown) => void;
+  class?: string;
+  style?: string;
+  id?: string;
+  /** Bind this prop to access the underlying WTerm instance. */
+  instance?: WTerm | null;
+  [key: string]: unknown;
+}
+
+export interface TerminalHandle {
+  write(data: string | Uint8Array): void;
+  resize(cols: number, rows: number): void;
+  focus(): void;
+}
+
+type TerminalEventMap = {
+  [K in keyof TerminalEvents]: CustomEvent<TerminalEvents[K]>;
+};
+
+export default class Terminal extends SvelteComponentTyped<
+  TerminalProps,
+  TerminalEventMap
+> {
+  write(data: string | Uint8Array): void;
+  resize(cols: number, rows: number): void;
+  focus(): void;
+}

--- a/packages/@wterm/svelte/src/lib/Terminal.svelte.d.ts
+++ b/packages/@wterm/svelte/src/lib/Terminal.svelte.d.ts
@@ -1,14 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { WTerm, WTermOptions } from "@wterm/dom";
 
-export interface TerminalEvents {
-  data: string;
-  title: string;
-  resize: [cols: number, rows: number];
-  ready: WTerm;
-  error: unknown;
-}
-
 export interface TerminalProps extends Omit<
   WTermOptions,
   "onData" | "onTitle" | "onResize"
@@ -39,14 +31,7 @@ export interface TerminalHandle {
   focus(): void;
 }
 
-type TerminalEventMap = {
-  [K in keyof TerminalEvents]: CustomEvent<TerminalEvents[K]>;
-};
-
-export default class Terminal extends SvelteComponentTyped<
-  TerminalProps,
-  TerminalEventMap
-> {
+export default class Terminal extends SvelteComponentTyped<TerminalProps> {
   write(data: string | Uint8Array): void;
   resize(cols: number, rows: number): void;
   focus(): void;

--- a/packages/@wterm/svelte/src/lib/index.d.ts
+++ b/packages/@wterm/svelte/src/lib/index.d.ts
@@ -1,0 +1,7 @@
+export { default as Terminal } from "./Terminal.svelte";
+export type {
+  TerminalEvents,
+  TerminalHandle,
+  TerminalProps,
+} from "./Terminal.svelte";
+export * from "@wterm/dom";

--- a/packages/@wterm/svelte/src/lib/index.d.ts
+++ b/packages/@wterm/svelte/src/lib/index.d.ts
@@ -1,7 +1,3 @@
 export { default as Terminal } from "./Terminal.svelte";
-export type {
-  TerminalEvents,
-  TerminalHandle,
-  TerminalProps,
-} from "./Terminal.svelte";
+export type { TerminalHandle, TerminalProps } from "./Terminal.svelte";
 export * from "@wterm/dom";

--- a/packages/@wterm/svelte/src/lib/index.js
+++ b/packages/@wterm/svelte/src/lib/index.js
@@ -1,0 +1,2 @@
+export { default as Terminal } from "./Terminal.svelte";
+export * from "@wterm/dom";

--- a/packages/@wterm/svelte/src/terminal.css
+++ b/packages/@wterm/svelte/src/terminal.css
@@ -1,0 +1,1 @@
+@import "../../dom/src/terminal.css";

--- a/packages/@wterm/svelte/svelte.config.js
+++ b/packages/@wterm/svelte/svelte.config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/@wterm/svelte/tsconfig.json
+++ b/packages/@wterm/svelte/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@internal/ts/tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.svelte"]
+}

--- a/packages/@wterm/svelte/vitest.config.ts
+++ b/packages/@wterm/svelte/vitest.config.ts
@@ -1,0 +1,13 @@
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [svelte()],
+  resolve: {
+    conditions: ["browser"],
+  },
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  next-themes@0.4.6: 73478c20fb87207168b5c0fa9ccabf0c042408da2bc5a36131ed1c8bb57bf5a3
+  next-themes@0.4.6:
+    hash: 73478c20fb87207168b5c0fa9ccabf0c042408da2bc5a36131ed1c8bb57bf5a3
+    path: patches/next-themes@0.4.6.patch
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  next-themes@0.4.6:
-    hash: 73478c20fb87207168b5c0fa9ccabf0c042408da2bc5a36131ed1c8bb57bf5a3
-    path: patches/next-themes@0.4.6.patch
+  next-themes@0.4.6: 73478c20fb87207168b5c0fa9ccabf0c042408da2bc5a36131ed1c8bb57bf5a3
 
 importers:
 
@@ -27,7 +25,7 @@ importers:
         version: 2.9.6
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
@@ -127,7 +125,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.3
-        version: 16.2.3(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.2.3(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -149,7 +147,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: ^6.3.5
-        version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/local:
     dependencies:
@@ -210,7 +208,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.3
-        version: 16.2.3(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+        version: 16.2.3(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
       tsx:
         specifier: ^4.19.4
         version: 4.21.0
@@ -419,6 +417,37 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
 
+  examples/svelte:
+    dependencies:
+      '@wterm/dom':
+        specifier: workspace:*
+        version: link:../../packages/@wterm/dom
+      '@wterm/just-bash':
+        specifier: workspace:*
+        version: link:../../packages/@wterm/just-bash
+      '@wterm/svelte':
+        specifier: workspace:*
+        version: link:../../packages/@wterm/svelte
+      just-bash:
+        specifier: ^2.14.2
+        version: 2.14.2
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.3.0
+        version: 7.3.0(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+      svelte:
+        specifier: ^5.57.0
+        version: 5.57.0(@typescript-eslint/types@8.58.2)
+      svelte-check:
+        specifier: ^4.7.6
+        version: 4.7.6(picomatch@4.0.4)(svelte@5.57.0(@typescript-eslint/types@8.58.2))(typescript@6.0.2)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vite:
+        specifier: ^8.2.2
+        version: 8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+
   examples/vite:
     dependencies:
       '@wterm/dom':
@@ -436,10 +465,10 @@ importers:
         version: 6.0.2
       vite:
         specifier: ^6.3.5
-        version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
         specifier: ^0.26.0
-        version: 0.26.0(rollup@4.60.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.26.0(rollup@4.60.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))
 
   examples/vue:
     dependencies:
@@ -470,7 +499,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
@@ -479,7 +508,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-vue':
         specifier: ^6.0.5
-        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
+        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.32(typescript@6.0.2))
       '@vue/tsconfig':
         specifier: ^0.9.1
         version: 0.9.1(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))
@@ -494,7 +523,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: ^8.0.4
-        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.7(typescript@6.0.2)
@@ -600,10 +629,10 @@ importers:
         version: link:../../@internal/ts
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.3.0
-        version: 7.3.0(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 7.3.0(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/svelte':
         specifier: ^5.4.2
-        version: 5.4.2(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 5.4.2(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4(vitest@4.1.4))(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)))
       '@wterm/dom':
         specifier: workspace:*
         version: link:../dom
@@ -615,13 +644,13 @@ importers:
         version: 5.57.0(@typescript-eslint/types@8.58.2)
       svelte-check:
         specifier: ^4.7.6
-        version: 4.7.6(picomatch@4.0.4)(svelte@5.57.0(@typescript-eslint/types@8.58.2))(typescript@6.0.2)
+        version: 4.7.6(picomatch@4.0.7)(svelte@5.57.0(@typescript-eslint/types@8.58.2))(typescript@6.0.2)
       typescript:
         specifier: ~6.0.2
         version: 6.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4(vitest@4.1.4))(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@wterm/vue:
     devDependencies:
@@ -642,7 +671,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))
+        version: 2.1.9(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.33.0)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))
       vue:
         specifier: ^3.5.0
         version: 3.5.32(typescript@6.0.2)
@@ -1525,89 +1554,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1786,24 +1831,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.3':
     resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.3':
     resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.3':
     resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
@@ -1828,6 +1877,9 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1863,6 +1915,9 @@ packages:
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@oxc-project/types@0.148.0':
+    resolution: {integrity: sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2563,8 +2618,20 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm-eabi@1.2.7':
+    resolution: {integrity: sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.7':
+    resolution: {integrity: sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -2575,8 +2642,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-arm64@1.2.7':
+    resolution: {integrity: sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-x64@1.0.0-rc.15':
     resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.7':
+    resolution: {integrity: sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2587,8 +2666,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-freebsd-x64@1.2.7':
+    resolution: {integrity: sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
     resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
+    resolution: {integrity: sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -2598,39 +2689,93 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.7':
+    resolution: {integrity: sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.7':
+    resolution: {integrity: sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.7':
+    resolution: {integrity: sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.7':
+    resolution: {integrity: sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.7':
+    resolution: {integrity: sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.2.7':
+    resolution: {integrity: sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.2.7':
+    resolution: {integrity: sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2646,8 +2791,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.7':
+    resolution: {integrity: sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.7':
+    resolution: {integrity: sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2657,6 +2814,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-inject@5.0.5':
     resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
@@ -2710,66 +2870,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2902,24 +3075,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -3314,41 +3491,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3618,6 +3803,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -3767,9 +3955,9 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4743,11 +4931,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.3.1:
+    resolution: {integrity: sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==}
 
-  fast-xml-parser@5.5.12:
-    resolution: {integrity: sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==}
+  fast-xml-parser@5.11.1:
+    resolution: {integrity: sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==}
     hasBin: true
 
   fastq@1.20.1:
@@ -5296,6 +5484,9 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
+  is-unsafe@2.0.2:
+    resolution: {integrity: sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -5474,8 +5665,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -5486,8 +5689,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -5498,32 +5713,76 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -5534,8 +5793,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
@@ -5836,8 +6105,8 @@ packages:
   minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
@@ -5860,8 +6129,8 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  modern-tar@0.7.6:
-    resolution: {integrity: sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==}
+  modern-tar@0.7.7:
+    resolution: {integrity: sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==}
     engines: {node: '>=18.0.0'}
 
   mri@1.2.0:
@@ -5893,6 +6162,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6097,8 +6371,8 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
-  papaparse@5.5.3:
-    resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
+  papaparse@5.7.0:
+    resolution: {integrity: sha512-qBGxg/7Q3Kl9Wfhrz2Z74UnvnHTXLNG6jmKJFeBvP2+y4lV7So+7SR62+Zd47JvdrCkX+nDcnr0ObPzek/+6RA==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6139,8 +6413,8 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.5.0:
-    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
     engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
@@ -6189,6 +6463,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -6226,6 +6504,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.9:
@@ -6524,6 +6806,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rolldown@1.2.7:
+    resolution: {integrity: sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -6677,8 +6964,8 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -6825,8 +7112,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.2.3:
-    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+  strnum@2.4.2:
+    resolution: {integrity: sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==}
 
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
@@ -6931,6 +7218,10 @@ packages:
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -7329,6 +7620,49 @@ packages:
       yaml:
         optional: true
 
+  vite@8.2.2:
+    resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0 || ^0.5.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.1.3:
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
@@ -7577,6 +7911,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -7593,6 +7931,11 @@ packages:
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -8648,6 +8991,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@3.0.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8676,6 +9021,8 @@ snapshots:
   '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/types@0.124.0': {}
+
+  '@oxc-project/types@0.148.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -9431,40 +9778,79 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm-eabi@1.2.7':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.7':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
     optional: true
 
+  '@rolldown/binding-darwin-arm64@1.2.7':
+    optional: true
+
   '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.7':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
     optional: true
 
+  '@rolldown/binding-freebsd-x64@1.2.7':
+    optional: true
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
     optional: true
 
+  '@rolldown/binding-linux-arm64-gnu@1.2.7':
+    optional: true
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.7':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     optional: true
 
+  '@rolldown/binding-linux-ppc64-gnu@1.2.7':
+    optional: true
+
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.7':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     optional: true
 
+  '@rolldown/binding-linux-x64-gnu@1.2.7':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.2.7':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.7':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
@@ -9477,12 +9863,20 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.7':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.7':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-inject@5.0.5(rollup@4.60.1)':
     dependencies:
@@ -9629,14 +10023,14 @@ snapshots:
 
   '@sveltejs/load-config@0.2.3': {}
 
-  '@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 1.2.3
       obug: 2.1.1
       svelte: 5.57.0(@typescript-eslint/types@8.58.2)
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vitefu: 1.1.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -9711,12 +10105,12 @@ snapshots:
       postcss: 8.5.9
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -9752,14 +10146,14 @@ snapshots:
     dependencies:
       svelte: 5.57.0(@typescript-eslint/types@8.58.2)
 
-  '@testing-library/svelte@5.4.2(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@testing-library/svelte@5.4.2(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4(vitest@4.1.4))(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.1.3(svelte@5.57.0(@typescript-eslint/types@8.58.2))
       svelte: 5.57.0(@typescript-eslint/types@8.58.2)
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vitest: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4(vitest@4.1.4))(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
@@ -9773,7 +10167,7 @@ snapshots:
   '@ts-morph/common@0.27.0':
     dependencies:
       fast-glob: 3.3.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       path-browserify: 1.0.1
 
   '@turbo/darwin-64@2.9.6':
@@ -10059,7 +10453,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.7.4
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.2)
@@ -10164,10 +10558,10 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))':
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.32(typescript@6.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       vue: 3.5.32(typescript@6.0.2)
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
@@ -10182,7 +10576,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -10209,32 +10603,32 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@2.1.9(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@2.1.9(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.33.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.3(@types/node@25.6.0)(typescript@6.0.2)
-      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.33.0)
 
-  '@vitest/mocker@4.1.11(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.11(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.3(@types/node@25.6.0)(typescript@6.0.2)
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.3(@types/node@25.6.0)(typescript@6.0.2)
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -10458,6 +10852,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  anynum@1.0.1: {}
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -10644,7 +11040,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11601,21 +11997,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
-      get-tsconfig: 4.13.7
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -11631,11 +12012,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      get-tsconfig: 4.13.7
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
@@ -11653,7 +12059,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11682,7 +12088,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11976,15 +12382,19 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.3.1:
     dependencies:
-      path-expression-matcher: 1.5.0
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
 
-  fast-xml-parser@5.5.12:
+  fast-xml-parser@5.11.1:
     dependencies:
-      fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.5.0
-      strnum: 2.2.3
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.1
+      is-unsafe: 2.0.2
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.2
+      xml-naming: 0.3.0
 
   fastq@1.20.1:
     dependencies:
@@ -11993,6 +12403,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
 
   fetch-blob@3.2.0:
     dependencies:
@@ -12585,6 +12999,8 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
+  is-unsafe@2.0.2: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -12724,20 +13140,20 @@ snapshots:
   just-bash@2.14.2:
     dependencies:
       diff: 8.0.4
-      fast-xml-parser: 5.5.12
+      fast-xml-parser: 5.11.1
       file-type: 21.3.4
       ini: 6.0.0
-      minimatch: 10.2.5
-      modern-tar: 0.7.6
-      papaparse: 5.5.3
+      minimatch: 10.2.6
+      modern-tar: 0.7.7
+      papaparse: 5.7.0
       quickjs-emscripten: 0.32.0
       re2js: 1.3.3
       seek-bzip: 2.0.0
-      smol-toml: 1.6.1
+      smol-toml: 1.8.0
       sprintf-js: 1.1.3
       sql.js: 1.14.1
       turndown: 7.2.4
-      yaml: 2.8.3
+      yaml: 2.9.0
     optionalDependencies:
       '@mongodb-js/zstd': 7.0.0
       node-liblzma: 2.2.0
@@ -12785,34 +13201,67 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.32.0:
@@ -12830,6 +13279,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   lines-and-columns@1.2.4: {}
 
@@ -13394,9 +13859,9 @@ snapshots:
 
   minimalistic-crypto-utils@1.0.1: {}
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
@@ -13420,7 +13885,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  modern-tar@0.7.6: {}
+  modern-tar@0.7.7: {}
 
   mri@1.2.0: {}
 
@@ -13459,6 +13924,8 @@ snapshots:
     optional: true
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -13712,7 +14179,7 @@ snapshots:
 
   pako@1.0.11: {}
 
-  papaparse@5.5.3: {}
+  papaparse@5.7.0: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -13761,7 +14228,7 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.5.0: {}
+  path-expression-matcher@1.6.2: {}
 
   path-key@3.1.1: {}
 
@@ -13798,6 +14265,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  picomatch@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
 
@@ -13836,6 +14305,12 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -14288,6 +14763,27 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
+  rolldown@1.2.7:
+    dependencies:
+      '@oxc-project/types': 0.148.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.7
+      '@rolldown/binding-android-arm64': 1.2.7
+      '@rolldown/binding-darwin-arm64': 1.2.7
+      '@rolldown/binding-darwin-x64': 1.2.7
+      '@rolldown/binding-freebsd-x64': 1.2.7
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.7
+      '@rolldown/binding-linux-arm64-gnu': 1.2.7
+      '@rolldown/binding-linux-arm64-musl': 1.2.7
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.7
+      '@rolldown/binding-linux-s390x-gnu': 1.2.7
+      '@rolldown/binding-linux-x64-gnu': 1.2.7
+      '@rolldown/binding-linux-x64-musl': 1.2.7
+      '@rolldown/binding-openharmony-arm64': 1.2.7
+      '@rolldown/binding-win32-arm64-msvc': 1.2.7
+      '@rolldown/binding-win32-x64-msvc': 1.2.7
+
   rollup@4.60.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -14582,7 +15078,7 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  smol-toml@1.6.1: {}
+  smol-toml@1.8.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -14768,7 +15264,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.2.3: {}
+  strnum@2.4.2:
+    dependencies:
+      anynum: 1.0.1
 
   strtok3@10.3.5:
     dependencies:
@@ -14803,6 +15301,19 @@ snapshots:
       '@sveltejs/load-config': 0.2.3
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.4)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.57.0(@typescript-eslint/types@8.58.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - picomatch
+
+  svelte-check@4.7.6(picomatch@4.0.7)(svelte@5.57.0(@typescript-eslint/types@8.58.2))(typescript@6.0.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@sveltejs/load-config': 0.2.3
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.7)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.57.0(@typescript-eslint/types@8.58.2)
@@ -14882,6 +15393,11 @@ snapshots:
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -15202,13 +15718,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@2.1.9(@types/node@25.6.0)(lightningcss@1.32.0):
+  vite-node@2.1.9(@types/node@25.6.0)(lightningcss@1.33.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.33.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15220,15 +15736,15 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-node-polyfills@0.26.0(rollup@4.60.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-node-polyfills@0.26.0(rollup@4.60.1)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.60.1)
       node-stdlib-browser: 1.3.1
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
 
-  vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0):
+  vite@5.4.21(@types/node@25.6.0)(lightningcss@1.33.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.9
@@ -15236,9 +15752,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       fsevents: 2.3.3
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
 
-  vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -15250,11 +15766,11 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       tsx: 4.21.0
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -15267,31 +15783,31 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.9
-      rolldown: 1.0.0-rc.15
-      tinyglobby: 0.2.16
+      lightningcss: 1.33.0
+      picomatch: 4.0.7
+      postcss: 8.5.26
+      rolldown: 1.2.7
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.6.0
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vitefu@1.1.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitefu@1.1.3(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@2.1.9(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2)):
+  vitest@2.1.9(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.33.0)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2)):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 2.1.9(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.33.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -15307,8 +15823,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
-      vite-node: 2.1.9(@types/node@25.6.0)(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.33.0)
+      vite-node: 2.1.9(@types/node@25.6.0)(lightningcss@1.33.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -15324,10 +15840,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4(vitest@4.1.4))(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.11(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -15344,7 +15860,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -15354,10 +15870,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -15374,7 +15890,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -15526,6 +16042,8 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
+  xml-naming@0.3.0: {}
+
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
@@ -15535,6 +16053,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,6 +593,36 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
 
+  packages/@wterm/svelte:
+    devDependencies:
+      '@internal/ts':
+        specifier: workspace:*
+        version: link:../../@internal/ts
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.3.0
+        version: 7.3.0(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@testing-library/svelte':
+        specifier: ^5.4.2
+        version: 5.4.2(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+      '@wterm/dom':
+        specifier: workspace:*
+        version: link:../dom
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
+      svelte:
+        specifier: ^5.57.0
+        version: 5.57.0(@typescript-eslint/types@8.58.2)
+      svelte-check:
+        specifier: ^4.7.6
+        version: 4.7.6(picomatch@4.0.4)(svelte@5.57.0(@typescript-eslint/types@8.58.2))(typescript@6.0.2)
+      typescript:
+        specifier: ~6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/@wterm/vue:
     devDependencies:
       '@internal/ts':
@@ -2815,6 +2845,22 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.13':
+    resolution: {integrity: sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/load-config@0.2.3':
+    resolution: {integrity: sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==}
+    engines: {node: '>= 18.0.0'}
+
+  '@sveltejs/vite-plugin-svelte@7.3.0':
+    resolution: {integrity: sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
+    peerDependencies:
+      svelte: ^5.46.4
+      vite: ^8.0.0-beta.7 || ^8.0.0
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2932,6 +2978,25 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@testing-library/svelte-core@1.1.3':
+    resolution: {integrity: sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.4.2':
+    resolution: {integrity: sha512-4o31E4HGo5BU5KwPkulNRocEden+7Tt9JYm9uhln5ajF7DULeyFA46BBWVfKJ8Ms9B3JmOFPTIiVamH7n3KpuQ==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
         optional: true
 
   '@tokenizer/inflate@0.4.1':
@@ -3208,6 +3273,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3342,6 +3408,9 @@ packages:
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
   '@vitest/expect@4.1.4':
     resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
@@ -3350,6 +3419,17 @@ packages:
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -3370,11 +3450,17 @@ packages:
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
   '@vitest/pretty-format@4.1.4':
     resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
   '@vitest/runner@2.1.9':
     resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
   '@vitest/runner@4.1.4':
     resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
@@ -3382,17 +3468,26 @@ packages:
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
 
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
   '@vitest/snapshot@4.1.4':
     resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
   '@vitest/spy@2.1.9':
     resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
   '@vitest/spy@4.1.4':
     resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
@@ -3532,6 +3627,10 @@ packages:
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -3794,6 +3893,10 @@ packages:
   chevrotain@12.0.0:
     resolution: {integrity: sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==}
     engines: {node: '>=22.0.0'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -4243,6 +4346,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  devalue@5.9.2:
+    resolution: {integrity: sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -4501,12 +4607,16 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
     peerDependenciesMeta:
       jiti:
         optional: true
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
@@ -4520,6 +4630,14 @@ packages:
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
+
+  esrap@2.3.6:
+    resolution: {integrity: sha512-yc0OC12UjPqLoc+fe+v5GNs4TOjAigUw3sTikfC+xeBPGUw7gDRz3DtYaqEhxyMVJojcSWJw7jT0QWR+CbuE/A==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -5131,6 +5249,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -5420,6 +5541,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -5465,6 +5589,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magic-string@1.2.3:
+    resolution: {integrity: sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==}
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
@@ -5736,6 +5863,10 @@ packages:
   modern-tar@0.7.6:
     resolution: {integrity: sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==}
     engines: {node: '>=18.0.0'}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -6269,6 +6400,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -6410,6 +6545,10 @@ packages:
 
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -6722,6 +6861,18 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svelte-check@4.7.6:
+    resolution: {integrity: sha512-t2scM//ZuVbSY/T2w6FSBw1v9s2NEmh/g+sy1lqtosW5ylBV5AF4wFb1Ts9Kf3MbfPDUDJDZ9L436YT0SPTdvw==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.0.0 || ^6.0.0
+
+  svelte@5.57.0:
+    resolution: {integrity: sha512-NdbDn7fl4be1ViUG0oq/lvG6OZy3oENolV2ONjiqqsfVoeAfzaQAKUcEX3MrQod/Bebv1PgwET9rfXhgn9s4Kg==}
+    engines: {node: '>=18'}
 
   swr@2.4.1:
     resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
@@ -7178,6 +7329,14 @@ packages:
       yaml:
         optional: true
 
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vitest@2.1.9:
     resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -7195,6 +7354,47 @@ packages:
       '@types/node':
         optional: true
       '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -7419,6 +7619,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zimmerframe@1.1.5:
+    resolution: {integrity: sha512-msJxIvYDYcoNL+PJsu+7qmpDWsYmAxTY+2TNYXXF0hzBzBk0BMecOqDOG/EckUoKCuKwObfbugIl8QpqHDXeFA==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -9420,6 +9623,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.13(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
+  '@sveltejs/load-config@0.2.3': {}
+
+  '@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      deepmerge: 4.3.1
+      magic-string: 1.2.3
+      obug: 2.1.1
+      svelte: 5.57.0(@typescript-eslint/types@8.58.2)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -9529,6 +9747,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/svelte-core@1.1.3(svelte@5.57.0(@typescript-eslint/types@8.58.2))':
+    dependencies:
+      svelte: 5.57.0(@typescript-eslint/types@8.58.2)
+
+  '@testing-library/svelte@5.4.2(svelte@5.57.0(@typescript-eslint/types@8.58.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.1.3(svelte@5.57.0(@typescript-eslint/types@8.58.2))
+      svelte: 5.57.0(@typescript-eslint/types@8.58.2)
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
@@ -9960,6 +10191,15 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -9978,6 +10218,15 @@ snapshots:
       msw: 2.13.3(@types/node@25.6.0)(typescript@6.0.2)
       vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
 
+  '@vitest/mocker@4.1.11(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.3(@types/node@25.6.0)(typescript@6.0.2)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
@@ -9991,6 +10240,10 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.0
+
   '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
@@ -9999,6 +10252,11 @@ snapshots:
     dependencies:
       '@vitest/utils': 2.1.9
       pathe: 1.1.2
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
 
   '@vitest/runner@4.1.4':
     dependencies:
@@ -10011,6 +10269,13 @@ snapshots:
       magic-string: 0.30.21
       pathe: 1.1.2
 
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/snapshot@4.1.4':
     dependencies:
       '@vitest/pretty-format': 4.1.4
@@ -10022,6 +10287,8 @@ snapshots:
     dependencies:
       tinyspy: 3.0.2
 
+  '@vitest/spy@4.1.11': {}
+
   '@vitest/spy@4.1.4': {}
 
   '@vitest/utils@2.1.9':
@@ -10029,6 +10296,12 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -10194,6 +10467,8 @@ snapshots:
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
+
+  aria-query@5.3.1: {}
 
   aria-query@5.3.2: {}
 
@@ -10517,6 +10792,10 @@ snapshots:
       '@chevrotain/regexp-to-ast': 12.0.0
       '@chevrotain/types': 12.0.0
       '@chevrotain/utils': 12.0.0
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
 
   chownr@1.1.4:
     optional: true
@@ -10969,6 +11248,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  devalue@5.9.2: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -11277,7 +11558,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.3
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -11506,6 +11787,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.16.0
@@ -11517,6 +11800,12 @@ snapshots:
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@2.3.6(@typescript-eslint/types@8.58.2):
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
+      '@typescript-eslint/types': 8.58.2
 
   esrecurse@4.3.0:
     dependencies:
@@ -12239,6 +12528,10 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -12525,6 +12818,8 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  locate-character@3.0.0: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -12561,6 +12856,10 @@ snapshots:
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@1.2.3:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -13107,6 +13406,8 @@ snapshots:
       ufo: 1.6.3
 
   modern-tar@0.7.6: {}
+
+  mri@1.2.0: {}
 
   ms@2.1.3: {}
 
@@ -13769,6 +14070,8 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  readdirp@4.1.2: {}
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -14025,6 +14328,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   rw@1.3.3: {}
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -14474,6 +14781,39 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svelte-check@4.7.6(picomatch@4.0.4)(svelte@5.57.0(@typescript-eslint/types@8.58.2))(typescript@6.0.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@sveltejs/load-config': 0.2.3
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.57.0(@typescript-eslint/types@8.58.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - picomatch
+
+  svelte@5.57.0(@typescript-eslint/types@8.58.2):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.16.0)
+      '@types/estree': 1.0.8
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.9.2
+      esm-env: 1.2.2
+      esrap: 2.3.6(@typescript-eslint/types@8.58.2)
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.5
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
 
   swr@2.4.1(react@19.2.5):
     dependencies:
@@ -14929,6 +15269,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
+  vitefu@1.1.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   vitest@2.1.9(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2)):
     dependencies:
       '@vitest/expect': 2.1.9
@@ -14964,6 +15308,36 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -15168,6 +15542,8 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zimmerframe@1.1.5: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11616,6 +11616,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      get-tsconfig: 4.13.7
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7


### PR DESCRIPTION
- add @wterm/svelte with lifecycle, callbacks, events, and imperative controls
- add Svelte tests, types, CSS/build tooling, and workspace dependencies
- document Svelte usage, configuration, themes, Ghostty integration, and APIs