### PR TITLE
fix(dom): prevent raw keydown leakage during IME composition

### DIFF
--- a/packages/@wterm/dom/src/__tests__/input.test.ts
+++ b/packages/@wterm/dom/src/__tests__/input.test.ts
@@ -423,6 +423,24 @@ describe("InputHandler", () => {
       expect(received).toEqual(["é"]);
     });
 
+    it("ignores the first keydown signaled as composing", () => {
+      const ta = getTextarea();
+      ta.dispatchEvent(createKeyboardEvent("s", { isComposing: true }));
+      ta.dispatchEvent(new CompositionEvent("compositionend", { data: "你" }));
+      expect(received).toEqual(["你"]);
+    });
+
+    it("ignores the legacy IME processing keydown", () => {
+      bridgeMock = { kittyKeyboardFlags: () => 31 } as any;
+      const ta = getTextarea();
+      ta.dispatchEvent(
+        createKeyboardEvent("s", { code: "KeyS", keyCode: 229 }),
+      );
+      ta.dispatchEvent(createKeyUpEvent("s", { code: "KeyS" }));
+      ta.dispatchEvent(new CompositionEvent("compositionend", { data: "好" }));
+      expect(received).toEqual(["好"]);
+    });
+
     it("clears a stale shortcut suppression on the next real keydown", () => {
       bridgeMock = { kittyKeyboardFlags: () => 31 } as any;
       const ta = getTextarea();

--- a/packages/@wterm/dom/src/input.ts
+++ b/packages/@wterm/dom/src/input.ts
@@ -199,7 +199,7 @@ export class InputHandler {
     if (physicalModifier) {
       this.pressedModifiers.add(e.code);
     }
-    if (this.composing) {
+    if (this.composing || e.isComposing || e.keyCode === 229) {
       this.suppressedKeyUps.add(keyId);
       return;
     }


### PR DESCRIPTION
Fixes #85

Browsers may deliver the first IME keydown before compositionstart, so InputHandler's internal composition flag is not set and the raw Latin key can be sent to the terminal. Treat KeyboardEvent.isComposing and the legacy IME keyCode === 229 as composition signals, suppress their keyups, and cover both browser paths with regression tests so CJK composition emits only the committed text.